### PR TITLE
Fix MCP portal command injection vulnerability

### DIFF
--- a/backend/src/services/portalService.test.ts
+++ b/backend/src/services/portalService.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateCommand,
+  validateArgs,
+  validateEnv,
+  ALLOWED_COMMANDS,
+  McpPortalAdapter,
+  CliPortalAdapter,
+  PortalService,
+} from './portalService.js';
+
+// ── validateCommand ─────────────────────────────────────────────────
+
+describe('validateCommand', () => {
+  it('accepts all allowed commands', () => {
+    for (const cmd of ALLOWED_COMMANDS) {
+      expect(() => validateCommand(cmd)).not.toThrow();
+    }
+  });
+
+  it('accepts allowed commands with .exe suffix', () => {
+    expect(() => validateCommand('node.exe')).not.toThrow();
+    expect(() => validateCommand('python.cmd')).not.toThrow();
+  });
+
+  it('accepts allowed commands with path prefix', () => {
+    expect(() => validateCommand('/usr/bin/node')).not.toThrow();
+    expect(() => validateCommand('C:\\Program Files\\node')).not.toThrow();
+  });
+
+  it('rejects empty command', () => {
+    expect(() => validateCommand('')).toThrow('non-empty string');
+  });
+
+  it('rejects arbitrary commands (command injection)', () => {
+    expect(() => validateCommand('bash')).toThrow('not allowed');
+    expect(() => validateCommand('sh')).toThrow('not allowed');
+    expect(() => validateCommand('cmd')).toThrow('not allowed');
+    expect(() => validateCommand('powershell')).toThrow('not allowed');
+    expect(() => validateCommand('curl')).toThrow('not allowed');
+    expect(() => validateCommand('rm')).toThrow('not allowed');
+    expect(() => validateCommand('/bin/sh')).toThrow('not allowed');
+  });
+
+  it('rejects commands that try to bypass via path traversal', () => {
+    expect(() => validateCommand('/tmp/../bin/bash')).toThrow('not allowed');
+    expect(() => validateCommand('../../etc/passwd')).toThrow('not allowed');
+  });
+});
+
+// ── validateArgs ────────────────────────────────────────────────────
+
+describe('validateArgs', () => {
+  it('returns undefined for undefined/null', () => {
+    expect(validateArgs(undefined)).toBeUndefined();
+    expect(validateArgs(null)).toBeUndefined();
+  });
+
+  it('accepts clean args', () => {
+    expect(validateArgs(['server.js', '--port', '3000'])).toEqual([
+      'server.js',
+      '--port',
+      '3000',
+    ]);
+  });
+
+  it('rejects non-array input', () => {
+    expect(() => validateArgs('not-an-array')).toThrow('array of strings');
+  });
+
+  it('rejects non-string elements', () => {
+    expect(() => validateArgs([123])).toThrow('must be a string');
+  });
+
+  it('rejects args with semicolons (command chaining)', () => {
+    expect(() => validateArgs(['server.js; rm -rf /'])).toThrow(
+      'shell metacharacters',
+    );
+  });
+
+  it('rejects args with pipe (command piping)', () => {
+    expect(() => validateArgs(['file.js | cat /etc/passwd'])).toThrow(
+      'shell metacharacters',
+    );
+  });
+
+  it('rejects args with backticks (command substitution)', () => {
+    expect(() => validateArgs(['`whoami`'])).toThrow('shell metacharacters');
+  });
+
+  it('rejects args with $() (command substitution)', () => {
+    expect(() => validateArgs(['$(id)'])).toThrow('shell metacharacters');
+  });
+
+  it('rejects args with ampersand (background execution)', () => {
+    expect(() => validateArgs(['file.js&'])).toThrow('shell metacharacters');
+  });
+
+  it('rejects args with newlines (command injection)', () => {
+    expect(() => validateArgs(['file.js\nrm -rf /'])).toThrow(
+      'shell metacharacters',
+    );
+  });
+});
+
+// ── validateEnv ─────────────────────────────────────────────────────
+
+describe('validateEnv', () => {
+  it('returns undefined for undefined/null', () => {
+    expect(validateEnv(undefined)).toBeUndefined();
+    expect(validateEnv(null)).toBeUndefined();
+  });
+
+  it('accepts clean env vars', () => {
+    expect(validateEnv({ API_KEY: 'abc123', NODE_ENV: 'production' })).toEqual({
+      API_KEY: 'abc123',
+      NODE_ENV: 'production',
+    });
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validateEnv('not-an-object')).toThrow('plain object');
+    expect(() => validateEnv([1, 2])).toThrow('plain object');
+  });
+
+  it('rejects non-string values', () => {
+    expect(() => validateEnv({ KEY: 123 })).toThrow('string value');
+  });
+
+  it('rejects env keys with shell metacharacters', () => {
+    expect(() => validateEnv({ 'KEY;DROP': 'val' })).toThrow(
+      'forbidden characters',
+    );
+  });
+
+  it('rejects env values with control characters', () => {
+    expect(() => validateEnv({ KEY: 'val\x00ue' })).toThrow(
+      'control characters',
+    );
+    expect(() => validateEnv({ KEY: 'val\x07ue' })).toThrow(
+      'control characters',
+    );
+  });
+
+  it('allows env values with tabs (not a control char for our purposes)', () => {
+    // Tab (\x09) is excluded from the control character range
+    expect(validateEnv({ KEY: 'value\twith\ttabs' })).toEqual({
+      KEY: 'value\twith\ttabs',
+    });
+  });
+});
+
+// ── McpPortalAdapter ────────────────────────────────────────────────
+
+describe('McpPortalAdapter', () => {
+  it('initializes with valid config', async () => {
+    const adapter = new McpPortalAdapter([]);
+    await adapter.initialize({
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-github'],
+      env: { GITHUB_TOKEN: 'ghp_abc123' },
+    });
+    const config = adapter.getMcpServerConfig();
+    expect(config.command).toBe('npx');
+    expect(config.args).toEqual(['-y', '@modelcontextprotocol/server-github']);
+    expect(config.env).toEqual({ GITHUB_TOKEN: 'ghp_abc123' });
+  });
+
+  it('rejects disallowed command', async () => {
+    const adapter = new McpPortalAdapter([]);
+    await expect(
+      adapter.initialize({ command: 'bash', args: ['-c', 'echo pwned'] }),
+    ).rejects.toThrow('not allowed');
+  });
+
+  it('rejects args with shell metacharacters', async () => {
+    const adapter = new McpPortalAdapter([]);
+    await expect(
+      adapter.initialize({ command: 'node', args: ['server.js; rm -rf /'] }),
+    ).rejects.toThrow('shell metacharacters');
+  });
+
+  it('rejects env values with control characters', async () => {
+    const adapter = new McpPortalAdapter([]);
+    await expect(
+      adapter.initialize({
+        command: 'node',
+        args: ['server.js'],
+        env: { EVIL: 'val\x00ue' },
+      }),
+    ).rejects.toThrow('control characters');
+  });
+});
+
+// ── CliPortalAdapter ────────────────────────────────────────────────
+
+describe('CliPortalAdapter', () => {
+  it('initializes with valid command', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({ command: 'python3' });
+    expect(adapter.getCommand()).toBe('python3');
+  });
+
+  it('rejects disallowed command', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await expect(
+      adapter.initialize({ command: '/bin/sh' }),
+    ).rejects.toThrow('not allowed');
+  });
+});
+
+// ── PortalService.initializePortals ─────────────────────────────────
+
+describe('PortalService.initializePortals', () => {
+  const fakeHardwareService = {} as any;
+
+  it('rejects portals with disallowed MCP commands', async () => {
+    const service = new PortalService(fakeHardwareService);
+    await expect(
+      service.initializePortals([
+        {
+          id: 'evil',
+          name: 'Evil',
+          description: 'Malicious portal',
+          mechanism: 'mcp',
+          capabilities: [],
+          interactions: [],
+          mcpConfig: { command: 'bash', args: ['-c', 'echo pwned'] },
+        },
+      ]),
+    ).rejects.toThrow('not allowed');
+  });
+
+  it('rejects portals with shell metacharacter args', async () => {
+    const service = new PortalService(fakeHardwareService);
+    await expect(
+      service.initializePortals([
+        {
+          id: 'inject',
+          name: 'Injector',
+          description: 'Injection attempt',
+          mechanism: 'mcp',
+          capabilities: [],
+          interactions: [],
+          mcpConfig: { command: 'npx', args: ['server; rm -rf /'] },
+        },
+      ]),
+    ).rejects.toThrow('shell metacharacters');
+  });
+
+  it('accepts portals with valid MCP config', async () => {
+    const service = new PortalService(fakeHardwareService);
+    await service.initializePortals([
+      {
+        id: 'github',
+        name: 'GitHub',
+        description: 'GitHub MCP',
+        mechanism: 'mcp',
+        capabilities: [],
+        interactions: [],
+        mcpConfig: {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-github'],
+          env: { GITHUB_TOKEN: 'ghp_abc123' },
+        },
+      },
+    ]);
+    const servers = service.getMcpServers();
+    expect(servers).toHaveLength(1);
+    expect(servers[0].command).toBe('npx');
+  });
+});

--- a/backend/src/utils/specValidator.test.ts
+++ b/backend/src/utils/specValidator.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { NuggetSpecSchema } from './specValidator.js';
+
+describe('NuggetSpecSchema portal config validation', () => {
+  const basePortal = {
+    name: 'TestPortal',
+    description: 'A test portal',
+    mechanism: 'mcp',
+    capabilities: [],
+    interactions: [],
+  };
+
+  it('accepts valid mcpConfig', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mcpConfig: {
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-github'],
+            env: { GITHUB_TOKEN: 'abc123' },
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects mcpConfig with shell metacharacters in args', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mcpConfig: {
+            command: 'npx',
+            args: ['server.js; rm -rf /'],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects mcpConfig with backtick command substitution in args', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mcpConfig: {
+            command: 'node',
+            args: ['`whoami`'],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects mcpConfig with $() substitution in args', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mcpConfig: {
+            command: 'node',
+            args: ['$(cat /etc/passwd)'],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects mcpConfig with unknown extra fields (strict mode)', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mcpConfig: {
+            command: 'node',
+            args: ['server.js'],
+            evil: 'injection',
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid cliConfig', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mechanism: 'cli',
+          cliConfig: {
+            command: 'python3',
+            args: ['script.py', '--flag'],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects cliConfig with shell metacharacters in args', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mechanism: 'cli',
+          cliConfig: {
+            command: 'python3',
+            args: ['script.py && rm -rf /'],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid serialConfig', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mechanism: 'serial',
+          serialConfig: {
+            port: 'COM3',
+            baudRate: 115200,
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects portal with unrecognized config fields', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          arbitraryField: 'should-not-be-here',
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects mcpConfig without required command field', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [
+        {
+          ...basePortal,
+          mcpConfig: {
+            args: ['server.js'],
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/utils/specValidator.ts
+++ b/backend/src/utils/specValidator.ts
@@ -14,12 +14,38 @@ const InteractionSchema = z.object({
   capabilityId: z.string().max(200).optional(),
 }).passthrough();
 
+/** Shell metacharacters forbidden in portal args. */
+const SHELL_META_RE = /[;&|`$(){}[\]<>!\n\r\\'"]/;
+const noShellMeta = z.string().max(500).refine(
+  (s) => !SHELL_META_RE.test(s),
+  { message: 'Arg contains forbidden shell metacharacters' },
+);
+
+const McpConfigSchema = z.object({
+  command: z.string().max(200),
+  args: z.array(noShellMeta).max(50).optional(),
+  env: z.record(z.string().max(200), z.string().max(1000)).optional(),
+}).strict();
+
+const CliConfigSchema = z.object({
+  command: z.string().max(200),
+  args: z.array(noShellMeta).max(50).optional(),
+}).strict();
+
+const SerialConfigSchema = z.object({
+  port: z.string().max(200).optional(),
+  baudRate: z.number().int().positive().optional(),
+}).strict();
+
 const PortalSchema = z.object({
   name: z.string().max(200).optional(),
   description: z.string().max(2000).optional(),
   mechanism: z.string().max(50).optional(),
   capabilities: z.array(CapabilitySchema).max(50).optional(),
   interactions: z.array(InteractionSchema).max(50).optional(),
+  mcpConfig: McpConfigSchema.optional(),
+  cliConfig: CliConfigSchema.optional(),
+  serialConfig: SerialConfigSchema.optional(),
 }).strict();
 
 const SkillSchema = z.object({


### PR DESCRIPTION
## Summary

- Add command allowlist validation in `portalService.ts` -- only `node`, `npx`, `python`, `python3`, `uvx`, `docker`, `deno`, `bun`, `bunx` are permitted as portal commands
- Validate portal args reject shell metacharacters (`;`, `&`, `|`, `` ` ``, `$()`, etc.)
- Sanitize env values to reject control characters
- Add strict Zod schemas for `mcpConfig`, `cliConfig`, and `serialConfig` in `specValidator.ts` (replaces untyped `Record<string, unknown>` passthrough)
- 42 regression tests covering command injection, shell metacharacter args, env poisoning, and Zod schema enforcement

## Test plan

- [x] `validateCommand` rejects `bash`, `sh`, `cmd`, `powershell`, `curl`, `rm`, path traversal attempts
- [x] `validateCommand` accepts all allowlisted commands including with `.exe`/`.cmd` suffixes and path prefixes
- [x] `validateArgs` rejects semicolons, pipes, backticks, `$()`, ampersands, newlines
- [x] `validateEnv` rejects control characters in values, shell metacharacters in keys
- [x] `McpPortalAdapter.initialize()` throws on disallowed command, bad args, bad env
- [x] `CliPortalAdapter.initialize()` throws on disallowed command
- [x] `PortalService.initializePortals()` rejects malicious portal specs end-to-end
- [x] Zod schema rejects mcpConfig with shell metacharacters in args, unknown fields, missing command
- [x] All 274 existing backend tests still pass (no regressions)

Closes #17