### PR TITLE
Add comprehensive tests for backend prompts module

### DIFF
--- a/backend/src/prompts/builderAgent.test.ts
+++ b/backend/src/prompts/builderAgent.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect } from 'vitest';
+import { SYSTEM_PROMPT, formatTaskPrompt, formatStyle } from './builderAgent.js';
+
+describe('builderAgent SYSTEM_PROMPT', () => {
+  it('contains all required placeholders', () => {
+    for (const ph of [
+      '{agent_name}',
+      '{nugget_goal}',
+      '{nugget_type}',
+      '{nugget_description}',
+      '{persona}',
+      '{allowed_paths}',
+      '{restricted_paths}',
+      '{task_id}',
+    ]) {
+      expect(SYSTEM_PROMPT).toContain(ph);
+    }
+  });
+
+  it('contains team briefing section', () => {
+    expect(SYSTEM_PROMPT).toContain('Team Briefing');
+    expect(SYSTEM_PROMPT).toContain('multi-agent team');
+  });
+
+  it('contains security restrictions', () => {
+    expect(SYSTEM_PROMPT).toContain('Security Restrictions');
+    expect(SYSTEM_PROMPT).toContain('kid_skill');
+    expect(SYSTEM_PROMPT).toContain('kid_rule');
+    expect(SYSTEM_PROMPT).toContain('user_input');
+  });
+
+  it('defines builder role', () => {
+    expect(SYSTEM_PROMPT).toContain('BUILDER');
+  });
+});
+
+describe('formatStyle', () => {
+  it('formats current frontend fields (visual + personality)', () => {
+    const result = formatStyle({ visual: 'Retro pixel art', personality: 'Playful' });
+    expect(result).toContain('Visual Style: Retro pixel art');
+    expect(result).toContain('Personality: Playful');
+  });
+
+  it('formats legacy fields (colors, theme, tone)', () => {
+    const result = formatStyle({ colors: 'blue', theme: 'ocean', tone: 'friendly' });
+    expect(result).toContain('Colors: blue');
+    expect(result).toContain('Theme: ocean');
+    expect(result).toContain('Tone: friendly');
+  });
+
+  it('handles mixed current and legacy fields', () => {
+    const result = formatStyle({ visual: 'Modern', colors: 'red', tone: 'casual' });
+    expect(result).toContain('Visual Style: Modern');
+    expect(result).toContain('Colors: red');
+    expect(result).toContain('Tone: casual');
+  });
+
+  it('returns fallback text for empty style object', () => {
+    expect(formatStyle({})).toBe('No specific style preferences.');
+  });
+
+  it('ignores unknown keys', () => {
+    const result = formatStyle({ unknown_key: 'value' });
+    expect(result).toBe('No specific style preferences.');
+  });
+
+  it('handles style with only one field', () => {
+    expect(formatStyle({ visual: 'Dark mode' })).toBe('Visual Style: Dark mode');
+  });
+});
+
+describe('formatTaskPrompt', () => {
+  const baseParams = {
+    agentName: 'Builder Bot',
+    role: 'builder',
+    persona: 'A friendly robot',
+    task: {
+      name: 'Build UI',
+      description: 'Create the main UI',
+      acceptance_criteria: ['Page renders', 'Button works'],
+    },
+    spec: {
+      nugget: { goal: 'A cool game', type: 'software', description: 'A fun game' },
+      deployment: { target: 'preview' },
+    },
+    predecessors: [],
+  };
+
+  it('includes task name and description', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('# Task: Build UI');
+    expect(result).toContain('Create the main UI');
+  });
+
+  it('includes acceptance criteria when present', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Acceptance Criteria');
+    expect(result).toContain('- Page renders');
+    expect(result).toContain('- Button works');
+  });
+
+  it('omits acceptance criteria section when empty array', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      task: { name: 'Test', description: 'Desc', acceptance_criteria: [] },
+    });
+    expect(result).not.toContain('Acceptance Criteria');
+  });
+
+  it('omits acceptance criteria section when undefined', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      task: { name: 'Test', description: 'Desc' },
+    });
+    expect(result).not.toContain('Acceptance Criteria');
+  });
+
+  it('includes nugget context with goal and description', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Nugget Context');
+    expect(result).toContain('Goal: A cool game');
+    expect(result).toContain('Description: A fun game');
+  });
+
+  it('shows "Not specified" when nugget goal is missing', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { nugget: {} },
+    });
+    expect(result).toContain('Goal: Not specified');
+  });
+
+  it('omits description when not provided in nugget', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { nugget: { goal: 'A game' } },
+    });
+    expect(result).toContain('Goal: A game');
+    expect(result).not.toContain('Description:');
+  });
+
+  it('handles completely missing nugget in spec', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {},
+    });
+    expect(result).toContain('Goal: Not specified');
+  });
+
+  it('includes requirements section when present', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        requirements: [
+          { type: 'feature', description: 'Add login' },
+          { type: 'constraint', description: 'Must be responsive' },
+        ],
+      },
+    });
+    expect(result).toContain('## Nugget Requirements');
+    expect(result).toContain('- [feature] Add login');
+    expect(result).toContain('- [constraint] Must be responsive');
+  });
+
+  it('handles requirement with missing type and description', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        requirements: [{}],
+      },
+    });
+    expect(result).toContain('- [feature] ');
+  });
+
+  it('omits requirements section when empty array', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { ...baseParams.spec, requirements: [] },
+    });
+    expect(result).not.toContain('## Nugget Requirements');
+  });
+
+  it('omits requirements section when missing', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain('## Nugget Requirements');
+  });
+
+  it('includes style preferences when style is provided', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      style: { visual: 'Neon colors', personality: 'Energetic' },
+    });
+    expect(result).toContain('## Style Preferences');
+    expect(result).toContain('Visual Style: Neon colors');
+    expect(result).toContain('Personality: Energetic');
+  });
+
+  it('omits style section when style is null', () => {
+    const result = formatTaskPrompt({ ...baseParams, style: null });
+    expect(result).not.toContain('## Style Preferences');
+  });
+
+  it('omits style section when style is undefined', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain('## Style Preferences');
+  });
+
+  it('includes predecessor summaries when present', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      predecessors: ['Created index.html with basic layout', 'Added CSS styling'],
+    });
+    expect(result).toContain('## WHAT HAPPENED BEFORE YOU');
+    expect(result).toContain('Created index.html with basic layout');
+    expect(result).toContain('Added CSS styling');
+  });
+
+  it('omits predecessors section when empty', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain('## WHAT HAPPENED BEFORE YOU');
+  });
+
+  it('includes deployment target when present', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { ...baseParams.spec, deployment: { target: 'esp32' } },
+    });
+    expect(result).toContain('## Deployment Target: esp32');
+  });
+
+  it('omits deployment target when not present', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { nugget: { goal: 'Test' } },
+    });
+    expect(result).not.toContain('## Deployment Target');
+  });
+
+  it('includes feature skills filtered by category', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [
+          { name: 'Jump', prompt: 'Make it jump', category: 'feature' },
+          { name: 'Sparkle', prompt: 'Add sparkles', category: 'style' },
+        ],
+      },
+    });
+    expect(result).toContain("## Detailed Feature Instructions (kid's skills)");
+    expect(result).toContain('<kid_skill name="Jump">');
+    expect(result).toContain('Make it jump');
+  });
+
+  it('includes style skills filtered by category', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [
+          { name: 'Sparkle', prompt: 'Add sparkles', category: 'style' },
+          { name: 'Jump', prompt: 'Make it jump', category: 'feature' },
+        ],
+      },
+    });
+    expect(result).toContain("## Detailed Style Instructions (kid's skills)");
+    expect(result).toContain('<kid_skill name="Sparkle">');
+    expect(result).toContain('Add sparkles');
+  });
+
+  it('omits feature skills section when none have feature category', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [{ name: 'Sparkle', prompt: 'Add sparkles', category: 'style' }],
+      },
+    });
+    expect(result).not.toContain("## Detailed Feature Instructions");
+  });
+
+  it('omits style skills section when none have style category', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [{ name: 'Jump', prompt: 'Make it jump', category: 'feature' }],
+      },
+    });
+    expect(result).not.toContain("## Detailed Style Instructions");
+  });
+
+  it('handles empty skills array', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { ...baseParams.spec, skills: [] },
+    });
+    expect(result).not.toContain("kid's skills");
+  });
+
+  it('includes on_task_complete rules', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        rules: [
+          { name: 'Check colors', prompt: 'Ensure bright colors', trigger: 'on_task_complete' },
+          { name: 'Before deploy', prompt: 'Validate', trigger: 'before_deploy' },
+        ],
+      },
+    });
+    expect(result).toContain("## Validation Rules (kid's rules)");
+    expect(result).toContain('<kid_rule name="Check colors">');
+    expect(result).toContain('Ensure bright colors');
+    // before_deploy rule should not appear
+    expect(result).not.toContain('Before deploy');
+  });
+
+  it('omits rules section when no on_task_complete rules', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        rules: [{ name: 'Deploy check', prompt: 'Check', trigger: 'before_deploy' }],
+      },
+    });
+    expect(result).not.toContain("## Validation Rules");
+  });
+
+  it('omits rules section when rules array is empty', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { ...baseParams.spec, rules: [] },
+    });
+    expect(result).not.toContain("## Validation Rules");
+  });
+
+  it('includes portal context with capabilities and interactions', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        portals: [
+          {
+            name: 'weather-api',
+            description: 'Weather data API',
+            mechanism: 'mcp',
+            capabilities: [
+              { kind: 'query', name: 'getTemp', description: 'Get temperature' },
+            ],
+            interactions: [
+              { type: 'ask', capabilityId: 'getTemp' },
+            ],
+          },
+        ],
+      },
+    });
+    expect(result).toContain('## Available Portals');
+    expect(result).toContain('<user_input name="portal:weather-api">');
+    expect(result).toContain('Description: Weather data API');
+    expect(result).toContain('Mechanism: mcp');
+    expect(result).toContain('[query] getTemp: Get temperature');
+    expect(result).toContain('ask: getTemp');
+  });
+
+  it('includes portal without capabilities or interactions', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        portals: [
+          {
+            name: 'serial-board',
+            description: 'ESP32 board',
+            mechanism: 'serial',
+          },
+        ],
+      },
+    });
+    expect(result).toContain('## Available Portals');
+    expect(result).toContain('Description: ESP32 board');
+    expect(result).toContain('Mechanism: serial');
+    expect(result).not.toContain('Capabilities:');
+    expect(result).not.toContain('Requested interactions:');
+  });
+
+  it('omits portals section when empty array', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { ...baseParams.spec, portals: [] },
+    });
+    expect(result).not.toContain('## Available Portals');
+  });
+
+  it('omits portals section when missing', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain('## Available Portals');
+  });
+
+  it('includes multiple portals', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        portals: [
+          { name: 'p1', description: 'Portal 1', mechanism: 'mcp' },
+          { name: 'p2', description: 'Portal 2', mechanism: 'cli' },
+        ],
+      },
+    });
+    expect(result).toContain('portal:p1');
+    expect(result).toContain('portal:p2');
+  });
+});

--- a/backend/src/prompts/metaPlanner.test.ts
+++ b/backend/src/prompts/metaPlanner.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMetaPlannerSystem,
+  META_PLANNER_SYSTEM,
+  metaPlannerUser,
+} from './metaPlanner.js';
+
+describe('buildMetaPlannerSystem', () => {
+  it('always includes base prompt sections', () => {
+    const result = buildMetaPlannerSystem({
+      nugget: { goal: 'A game', type: 'software' },
+    });
+    expect(result).toContain('Meta-Planner for Elisa');
+    expect(result).toContain('## Your Job');
+    expect(result).toContain('## Task Decomposition Rules');
+    expect(result).toContain('## Agent Assignment Rules');
+    expect(result).toContain('## Output JSON Schema');
+    expect(result).toContain('## Deployment Rules');
+    expect(result).toContain('## Workflow Hints');
+    expect(result).toContain('## Skills and Rules');
+    expect(result).toContain('## Examples');
+    expect(result).toContain('## Important');
+  });
+
+  describe('hardware section inclusion', () => {
+    it('includes hardware section when nugget type is hardware', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'Blink LED', type: 'hardware' },
+      });
+      expect(result).toContain('## Hardware Nugget Rules');
+      expect(result).toContain('elisa_hardware');
+      expect(result).toContain('py_compile');
+    });
+
+    it('includes hardware section when deploy target is esp32', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'IoT sensor', type: 'software' },
+        deployment: { target: 'esp32' },
+      });
+      expect(result).toContain('## Hardware Nugget Rules');
+    });
+
+    it('includes hardware section when deploy target is both', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'IoT dashboard', type: 'software' },
+        deployment: { target: 'both' },
+      });
+      expect(result).toContain('## Hardware Nugget Rules');
+    });
+
+    it('excludes hardware section for software type with preview target', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'A game', type: 'software' },
+        deployment: { target: 'preview' },
+      });
+      expect(result).not.toContain('## Hardware Nugget Rules');
+    });
+
+    it('excludes hardware section for software type with web target', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'A site', type: 'software' },
+        deployment: { target: 'web' },
+      });
+      expect(result).not.toContain('## Hardware Nugget Rules');
+    });
+
+    it('excludes hardware section when deploy target is absent', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'A game', type: 'software' },
+      });
+      expect(result).not.toContain('## Hardware Nugget Rules');
+    });
+  });
+
+  describe('portal section inclusion', () => {
+    it('includes portal section when portals array is non-empty', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'Weather app', type: 'software' },
+        portals: [{ name: 'weather', mechanism: 'mcp' }],
+      });
+      expect(result).toContain('## Portals');
+      expect(result).toContain('serial');
+      expect(result).toContain('mcp');
+      expect(result).toContain('cli');
+    });
+
+    it('excludes portal section when portals array is empty', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'A game', type: 'software' },
+        portals: [],
+      });
+      expect(result).not.toContain('## Portals');
+    });
+
+    it('excludes portal section when portals is missing', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'A game', type: 'software' },
+      });
+      expect(result).not.toContain('## Portals');
+    });
+
+    it('excludes portal section when portals is not an array', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'A game', type: 'software' },
+        portals: 'not-an-array',
+      });
+      expect(result).not.toContain('## Portals');
+    });
+  });
+
+  describe('combined hardware and portal sections', () => {
+    it('includes both when both conditions are met', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'IoT weather station', type: 'hardware' },
+        deployment: { target: 'esp32' },
+        portals: [{ name: 'sensor-api', mechanism: 'mcp' }],
+      });
+      expect(result).toContain('## Hardware Nugget Rules');
+      expect(result).toContain('## Portals');
+    });
+
+    it('hardware section comes before portal section', () => {
+      const result = buildMetaPlannerSystem({
+        nugget: { goal: 'IoT', type: 'hardware' },
+        portals: [{ name: 'api', mechanism: 'mcp' }],
+      });
+      const hwIdx = result.indexOf('## Hardware Nugget Rules');
+      const portalIdx = result.indexOf('## Portals');
+      expect(hwIdx).toBeLessThan(portalIdx);
+    });
+  });
+
+  it('defaults nugget type to software when missing', () => {
+    const result = buildMetaPlannerSystem({});
+    expect(result).not.toContain('## Hardware Nugget Rules');
+  });
+
+  it('defaults deploy target to preview when missing', () => {
+    const result = buildMetaPlannerSystem({
+      nugget: { goal: 'Test' },
+    });
+    expect(result).not.toContain('## Hardware Nugget Rules');
+  });
+
+  it('examples section appears after conditional sections', () => {
+    const result = buildMetaPlannerSystem({
+      nugget: { type: 'hardware' },
+      portals: [{ name: 'x', mechanism: 'cli' }],
+    });
+    const hwIdx = result.indexOf('## Hardware Nugget Rules');
+    const portalIdx = result.indexOf('## Portals');
+    const examplesIdx = result.indexOf('## Examples');
+    expect(hwIdx).toBeLessThan(examplesIdx);
+    expect(portalIdx).toBeLessThan(examplesIdx);
+  });
+
+  it('footer (## Important) is always last', () => {
+    const result = buildMetaPlannerSystem({
+      nugget: { goal: 'Test', type: 'software' },
+    });
+    const importantIdx = result.indexOf('## Important');
+    const examplesIdx = result.indexOf('## Examples');
+    expect(importantIdx).toBeGreaterThan(examplesIdx);
+  });
+});
+
+describe('META_PLANNER_SYSTEM (deprecated constant)', () => {
+  it('includes all sections unconditionally', () => {
+    expect(META_PLANNER_SYSTEM).toContain('Meta-Planner for Elisa');
+    expect(META_PLANNER_SYSTEM).toContain('## Hardware Nugget Rules');
+    expect(META_PLANNER_SYSTEM).toContain('## Portals');
+    expect(META_PLANNER_SYSTEM).toContain('## Examples');
+    expect(META_PLANNER_SYSTEM).toContain('## Important');
+  });
+});
+
+describe('metaPlannerUser', () => {
+  it('wraps spec JSON into a user prompt', () => {
+    const spec = JSON.stringify({ nugget: { goal: 'A game' } });
+    const result = metaPlannerUser(spec);
+    expect(result).toContain("kid's nugget specification");
+    expect(result).toContain('NuggetSpec:');
+    expect(result).toContain(spec);
+  });
+
+  it('preserves exact JSON content', () => {
+    const spec = '{"nugget":{"goal":"Test","type":"software"},"portals":[]}';
+    const result = metaPlannerUser(spec);
+    expect(result).toContain(spec);
+  });
+});

--- a/backend/src/prompts/reviewerAgent.test.ts
+++ b/backend/src/prompts/reviewerAgent.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { SYSTEM_PROMPT, formatTaskPrompt } from './reviewerAgent.js';
+
+describe('reviewerAgent SYSTEM_PROMPT', () => {
+  it('contains all required placeholders', () => {
+    for (const ph of [
+      '{agent_name}',
+      '{nugget_goal}',
+      '{nugget_type}',
+      '{nugget_description}',
+      '{persona}',
+      '{allowed_paths}',
+      '{restricted_paths}',
+      '{task_id}',
+    ]) {
+      expect(SYSTEM_PROMPT).toContain(ph);
+    }
+  });
+
+  it('contains team briefing section', () => {
+    expect(SYSTEM_PROMPT).toContain('Team Briefing');
+    expect(SYSTEM_PROMPT).toContain('multi-agent team');
+  });
+
+  it('defines reviewer role', () => {
+    expect(SYSTEM_PROMPT).toContain('REVIEWER');
+  });
+
+  it('contains review checklist', () => {
+    expect(SYSTEM_PROMPT).toContain('Review Checklist');
+    expect(SYSTEM_PROMPT).toContain('acceptance criteria');
+  });
+
+  it('contains reporting format with verdict', () => {
+    expect(SYSTEM_PROMPT).toContain('APPROVED');
+    expect(SYSTEM_PROMPT).toContain('NEEDS_CHANGES');
+  });
+
+  it('contains security restrictions', () => {
+    expect(SYSTEM_PROMPT).toContain('Security Restrictions');
+    expect(SYSTEM_PROMPT).toContain('kid_skill');
+    expect(SYSTEM_PROMPT).toContain('kid_rule');
+    expect(SYSTEM_PROMPT).toContain('user_input');
+  });
+});
+
+describe('reviewerAgent formatTaskPrompt', () => {
+  const baseParams = {
+    agentName: 'Review Bot',
+    role: 'reviewer',
+    persona: 'A helpful teacher',
+    task: {
+      name: 'Review code',
+      description: 'Review all builder code',
+      acceptance_criteria: ['Code quality acceptable', 'No bugs found'],
+    },
+    spec: {
+      nugget: { goal: 'A todo app', type: 'software' },
+      deployment: { target: 'preview' },
+    },
+    predecessors: [],
+  };
+
+  it('includes task name and description', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('# Task: Review code');
+    expect(result).toContain('Review all builder code');
+  });
+
+  it('includes acceptance criteria', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Acceptance Criteria to Verify');
+    expect(result).toContain('- Code quality acceptable');
+    expect(result).toContain('- No bugs found');
+  });
+
+  it('omits acceptance criteria when empty', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      task: { name: 'R', description: 'D', acceptance_criteria: [] },
+    });
+    expect(result).not.toContain('Acceptance Criteria');
+  });
+
+  it('omits acceptance criteria when undefined', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      task: { name: 'R', description: 'D' },
+    });
+    expect(result).not.toContain('Acceptance Criteria');
+  });
+
+  it('includes nugget context', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Nugget Context');
+    expect(result).toContain('Goal: A todo app');
+  });
+
+  it('shows "Not specified" for missing goal', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { nugget: {} },
+    });
+    expect(result).toContain('Goal: Not specified');
+  });
+
+  it('handles missing nugget in spec', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {},
+    });
+    expect(result).toContain('Goal: Not specified');
+  });
+
+  it('includes style preferences when provided', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      style: { visual: 'Pastel colors', personality: 'Calm' },
+    });
+    expect(result).toContain('## Style Preferences');
+    expect(result).toContain('Visual Style: Pastel colors');
+    expect(result).toContain('Personality: Calm');
+  });
+
+  it('omits style when null', () => {
+    const result = formatTaskPrompt({ ...baseParams, style: null });
+    expect(result).not.toContain('## Style Preferences');
+  });
+
+  it('omits style when undefined', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain('## Style Preferences');
+  });
+
+  it('includes legacy style fields', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      style: { colors: 'blue', theme: 'ocean', tone: 'friendly' },
+    });
+    expect(result).toContain('Colors: blue');
+    expect(result).toContain('Theme: ocean');
+    expect(result).toContain('Tone: friendly');
+  });
+
+  it('includes predecessor summaries when present', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      predecessors: ['Built HTML structure', 'Tests all pass'],
+    });
+    expect(result).toContain('## WHAT HAPPENED BEFORE YOU');
+    expect(result).toContain('Built HTML structure');
+    expect(result).toContain('Tests all pass');
+  });
+
+  it('omits predecessors section when empty', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain('## WHAT HAPPENED BEFORE YOU');
+  });
+
+  it('includes review instructions', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Instructions');
+    expect(result).toContain('Read all code');
+    expect(result).toContain('acceptance criterion');
+    expect(result).toContain('Review code quality');
+  });
+
+  it('includes feature skills', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [
+          { name: 'Dance', prompt: 'Make it dance', category: 'feature' },
+        ],
+      },
+    });
+    expect(result).toContain("## Detailed Feature Instructions (kid's skills)");
+    expect(result).toContain('<kid_skill name="Dance">');
+  });
+
+  it('includes style skills', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [
+          { name: 'Glow', prompt: 'Add glow effect', category: 'style' },
+        ],
+      },
+    });
+    expect(result).toContain("## Detailed Style Instructions (kid's skills)");
+    expect(result).toContain('<kid_skill name="Glow">');
+  });
+
+  it('includes on_task_complete rules only', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        rules: [
+          { name: 'Final check', prompt: 'Verify output', trigger: 'on_task_complete' },
+          { name: 'Lint', prompt: 'Run linter', trigger: 'before_deploy' },
+        ],
+      },
+    });
+    expect(result).toContain("## Validation Rules (kid's rules)");
+    expect(result).toContain('<kid_rule name="Final check">');
+    expect(result).not.toContain('Lint');
+  });
+
+  it('omits rules section when empty', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { ...baseParams.spec, rules: [] },
+    });
+    expect(result).not.toContain("## Validation Rules");
+  });
+
+  it('omits skills/rules sections when missing from spec', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain("kid's skills");
+    expect(result).not.toContain("kid's rules");
+  });
+
+  it('does NOT include portals (reviewer has no portal section)', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        portals: [{ name: 'api', description: 'An API', mechanism: 'mcp' }],
+      },
+    });
+    expect(result).not.toContain('## Available Portals');
+  });
+});

--- a/backend/src/prompts/teaching.test.ts
+++ b/backend/src/prompts/teaching.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONCEPT_CURRICULUM,
+  getCurriculumMoment,
+  TEACHING_SYSTEM_PROMPT,
+  teachingUserPrompt,
+  type TeachingMomentData,
+} from './teaching.js';
+
+describe('CONCEPT_CURRICULUM', () => {
+  it('contains all expected top-level concept categories', () => {
+    const expected = [
+      'source_control',
+      'testing',
+      'decomposition',
+      'hardware',
+      'prompt_engineering',
+      'code_review',
+    ];
+    for (const cat of expected) {
+      expect(CONCEPT_CURRICULUM).toHaveProperty(cat);
+    }
+  });
+
+  it('source_control has expected sub-concepts', () => {
+    const sc = CONCEPT_CURRICULUM.source_control;
+    expect(sc).toHaveProperty('first_commit');
+    expect(sc).toHaveProperty('multiple_commits');
+    expect(sc).toHaveProperty('commit_messages');
+  });
+
+  it('testing has expected sub-concepts', () => {
+    const t = CONCEPT_CURRICULUM.testing;
+    expect(t).toHaveProperty('first_test_run');
+    expect(t).toHaveProperty('test_pass');
+    expect(t).toHaveProperty('test_fail');
+    expect(t).toHaveProperty('coverage');
+  });
+
+  it('decomposition has expected sub-concepts', () => {
+    const d = CONCEPT_CURRICULUM.decomposition;
+    expect(d).toHaveProperty('task_breakdown');
+    expect(d).toHaveProperty('dependencies');
+  });
+
+  it('hardware has expected sub-concepts', () => {
+    const h = CONCEPT_CURRICULUM.hardware;
+    expect(h).toHaveProperty('gpio');
+    expect(h).toHaveProperty('lora');
+    expect(h).toHaveProperty('compilation');
+    expect(h).toHaveProperty('flashing');
+  });
+
+  it('prompt_engineering has expected sub-concepts', () => {
+    const pe = CONCEPT_CURRICULUM.prompt_engineering;
+    expect(pe).toHaveProperty('first_skill');
+    expect(pe).toHaveProperty('first_rule');
+  });
+
+  it('code_review has expected sub-concepts', () => {
+    const cr = CONCEPT_CURRICULUM.code_review;
+    expect(cr).toHaveProperty('first_review');
+    expect(cr).toHaveProperty('review_feedback');
+    expect(cr).toHaveProperty('review_approval');
+  });
+
+  it('every curriculum entry has required fields', () => {
+    for (const [concept, subConcepts] of Object.entries(CONCEPT_CURRICULUM)) {
+      for (const [subKey, data] of Object.entries(subConcepts)) {
+        const entry = data as TeachingMomentData;
+        expect(entry.concept, `${concept}.${subKey}.concept`).toBe(concept);
+        expect(entry.headline, `${concept}.${subKey}.headline`).toBeTruthy();
+        expect(entry.explanation, `${concept}.${subKey}.explanation`).toBeTruthy();
+        expect(entry.tell_me_more, `${concept}.${subKey}.tell_me_more`).toBeTruthy();
+      }
+    }
+  });
+
+  it('explanations are kid-friendly (not too long)', () => {
+    for (const [concept, subConcepts] of Object.entries(CONCEPT_CURRICULUM)) {
+      for (const [subKey, data] of Object.entries(subConcepts)) {
+        const entry = data as TeachingMomentData;
+        // Each explanation should be reasonable length for kids
+        expect(
+          entry.explanation.length,
+          `${concept}.${subKey}.explanation too long`,
+        ).toBeLessThan(500);
+      }
+    }
+  });
+});
+
+describe('getCurriculumMoment', () => {
+  it('returns data for valid concept + sub-concept', () => {
+    const result = getCurriculumMoment('source_control', 'first_commit');
+    expect(result).not.toBeNull();
+    expect(result!.concept).toBe('source_control');
+    expect(result!.headline).toContain('saving their work');
+  });
+
+  it('returns data for testing.test_pass', () => {
+    const result = getCurriculumMoment('testing', 'test_pass');
+    expect(result).not.toBeNull();
+    expect(result!.concept).toBe('testing');
+    expect(result!.headline).toContain('passing');
+  });
+
+  it('returns data for testing.test_fail', () => {
+    const result = getCurriculumMoment('testing', 'test_fail');
+    expect(result).not.toBeNull();
+    expect(result!.headline).toContain('issues');
+  });
+
+  it('returns data for hardware.gpio', () => {
+    const result = getCurriculumMoment('hardware', 'gpio');
+    expect(result).not.toBeNull();
+    expect(result!.headline).toContain('GPIO');
+  });
+
+  it('returns data for hardware.lora', () => {
+    const result = getCurriculumMoment('hardware', 'lora');
+    expect(result).not.toBeNull();
+    expect(result!.headline).toContain('LoRa');
+  });
+
+  it('returns data for decomposition.dependencies', () => {
+    const result = getCurriculumMoment('decomposition', 'dependencies');
+    expect(result).not.toBeNull();
+    expect(result!.headline).toContain('depend');
+  });
+
+  it('returns data for prompt_engineering.first_skill', () => {
+    const result = getCurriculumMoment('prompt_engineering', 'first_skill');
+    expect(result).not.toBeNull();
+    expect(result!.headline).toContain('prompt engineering');
+  });
+
+  it('returns data for code_review.first_review', () => {
+    const result = getCurriculumMoment('code_review', 'first_review');
+    expect(result).not.toBeNull();
+    expect(result!.headline).toContain('reviewing');
+  });
+
+  it('returns null for unknown concept', () => {
+    expect(getCurriculumMoment('nonexistent', 'first_commit')).toBeNull();
+  });
+
+  it('returns null for unknown sub-concept', () => {
+    expect(getCurriculumMoment('source_control', 'nonexistent')).toBeNull();
+  });
+
+  it('returns null for both unknown concept and sub-concept', () => {
+    expect(getCurriculumMoment('x', 'y')).toBeNull();
+  });
+});
+
+describe('TEACHING_SYSTEM_PROMPT', () => {
+  it('targets kids aged 8-14', () => {
+    expect(TEACHING_SYSTEM_PROMPT).toContain('8-14');
+  });
+
+  it('requests JSON response format', () => {
+    expect(TEACHING_SYSTEM_PROMPT).toContain('JSON');
+    expect(TEACHING_SYSTEM_PROMPT).toContain('concept');
+    expect(TEACHING_SYSTEM_PROMPT).toContain('headline');
+    expect(TEACHING_SYSTEM_PROMPT).toContain('explanation');
+    expect(TEACHING_SYSTEM_PROMPT).toContain('tell_me_more');
+  });
+
+  it('asks for simple encouraging language', () => {
+    expect(TEACHING_SYSTEM_PROMPT).toContain('simple');
+    expect(TEACHING_SYSTEM_PROMPT).toContain('encouraging');
+  });
+});
+
+describe('teachingUserPrompt', () => {
+  it('includes event type and details', () => {
+    const result = teachingUserPrompt('commit_created', 'Added login page');
+    expect(result).toContain('commit_created');
+    expect(result).toContain('Added login page');
+  });
+
+  it('includes nugget type', () => {
+    const result = teachingUserPrompt('test_pass', '5 tests passed', 'hardware');
+    expect(result).toContain('hardware nugget');
+  });
+
+  it('defaults nugget type to software', () => {
+    const result = teachingUserPrompt('test_fail', '2 tests failed');
+    expect(result).toContain('software nugget');
+  });
+
+  it('requests JSON response format', () => {
+    const result = teachingUserPrompt('task_started', 'Building UI');
+    expect(result).toContain('JSON');
+    expect(result).toContain('concept');
+    expect(result).toContain('headline');
+    expect(result).toContain('explanation');
+    expect(result).toContain('tell_me_more');
+  });
+
+  it('mentions kid-friendly context', () => {
+    const result = teachingUserPrompt('plan_ready', 'Plan has 5 tasks');
+    expect(result).toContain('kid');
+    expect(result).toContain('AI agents');
+  });
+});

--- a/backend/src/prompts/testerAgent.test.ts
+++ b/backend/src/prompts/testerAgent.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { SYSTEM_PROMPT, formatTaskPrompt } from './testerAgent.js';
+
+describe('testerAgent SYSTEM_PROMPT', () => {
+  it('contains all required placeholders', () => {
+    for (const ph of [
+      '{agent_name}',
+      '{nugget_goal}',
+      '{nugget_type}',
+      '{nugget_description}',
+      '{persona}',
+      '{allowed_paths}',
+      '{restricted_paths}',
+      '{task_id}',
+    ]) {
+      expect(SYSTEM_PROMPT).toContain(ph);
+    }
+  });
+
+  it('contains team briefing section', () => {
+    expect(SYSTEM_PROMPT).toContain('Team Briefing');
+    expect(SYSTEM_PROMPT).toContain('multi-agent team');
+  });
+
+  it('defines tester role', () => {
+    expect(SYSTEM_PROMPT).toContain('TESTER');
+  });
+
+  it('contains security restrictions', () => {
+    expect(SYSTEM_PROMPT).toContain('Security Restrictions');
+  });
+
+  it('includes PASS/FAIL reporting format', () => {
+    expect(SYSTEM_PROMPT).toContain('PASS or FAIL');
+  });
+});
+
+describe('testerAgent formatTaskPrompt', () => {
+  const baseParams = {
+    agentName: 'Test Bot',
+    role: 'tester',
+    persona: 'A detective',
+    task: {
+      name: 'Test login',
+      description: 'Verify login works',
+      acceptance_criteria: ['Login succeeds', 'Error shown on bad password'],
+    },
+    spec: {
+      nugget: { goal: 'A user portal', type: 'software' },
+      deployment: { target: 'preview' },
+    },
+    predecessors: [],
+  };
+
+  it('includes task name and description', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('# Task: Test login');
+    expect(result).toContain('Verify login works');
+  });
+
+  it('includes acceptance criteria', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Acceptance Criteria to Verify');
+    expect(result).toContain('- Login succeeds');
+    expect(result).toContain('- Error shown on bad password');
+  });
+
+  it('omits acceptance criteria when empty', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      task: { name: 'T', description: 'D', acceptance_criteria: [] },
+    });
+    expect(result).not.toContain('Acceptance Criteria');
+  });
+
+  it('omits acceptance criteria when undefined', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      task: { name: 'T', description: 'D' },
+    });
+    expect(result).not.toContain('Acceptance Criteria');
+  });
+
+  it('includes nugget context', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Nugget Context');
+    expect(result).toContain('Goal: A user portal');
+  });
+
+  it('shows "Not specified" when nugget goal is missing', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: { nugget: {} },
+    });
+    expect(result).toContain('Goal: Not specified');
+  });
+
+  it('handles missing nugget in spec', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {},
+    });
+    expect(result).toContain('Goal: Not specified');
+  });
+
+  describe('tech stack selection', () => {
+    it('shows MicroPython tech stack for hardware nugget type', () => {
+      const result = formatTaskPrompt({
+        ...baseParams,
+        spec: {
+          nugget: { goal: 'Blink LED', type: 'hardware' },
+          deployment: { target: 'esp32' },
+        },
+      });
+      expect(result).toContain('## Tech Stack');
+      expect(result).toContain('MicroPython');
+      expect(result).toContain('py_compile');
+      expect(result).toContain('ESP32');
+    });
+
+    it('shows MicroPython tech stack for esp32 deploy target with software type', () => {
+      const result = formatTaskPrompt({
+        ...baseParams,
+        spec: {
+          nugget: { goal: 'Blink', type: 'software' },
+          deployment: { target: 'esp32' },
+        },
+      });
+      expect(result).toContain('MicroPython');
+    });
+
+    it('shows MicroPython tech stack for "both" deploy target', () => {
+      const result = formatTaskPrompt({
+        ...baseParams,
+        spec: {
+          nugget: { goal: 'IoT app', type: 'software' },
+          deployment: { target: 'both' },
+        },
+      });
+      expect(result).toContain('MicroPython');
+    });
+
+    it('shows software tech stack for preview deploy target', () => {
+      const result = formatTaskPrompt({
+        ...baseParams,
+        spec: {
+          nugget: { goal: 'A game', type: 'software' },
+          deployment: { target: 'preview' },
+        },
+      });
+      expect(result).toContain('## Tech Stack');
+      expect(result).toContain('pytest');
+      expect(result).toContain('Vitest');
+      expect(result).not.toContain('MicroPython');
+    });
+
+    it('shows software tech stack when deploy target is absent', () => {
+      const result = formatTaskPrompt({
+        ...baseParams,
+        spec: {
+          nugget: { goal: 'A game', type: 'software' },
+        },
+      });
+      expect(result).toContain('pytest');
+      expect(result).toContain('Vitest');
+    });
+
+    it('shows software tech stack for web deploy target', () => {
+      const result = formatTaskPrompt({
+        ...baseParams,
+        spec: {
+          nugget: { goal: 'A site', type: 'software' },
+          deployment: { target: 'web' },
+        },
+      });
+      expect(result).toContain('pytest');
+      expect(result).not.toContain('MicroPython');
+    });
+  });
+
+  it('includes predecessor summaries when present', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      predecessors: ['Built the login page', 'Added CSS'],
+    });
+    expect(result).toContain('## WHAT HAPPENED BEFORE YOU');
+    expect(result).toContain('Built the login page');
+    expect(result).toContain('Added CSS');
+  });
+
+  it('omits predecessors section when empty', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain('## WHAT HAPPENED BEFORE YOU');
+  });
+
+  it('includes testing instructions', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).toContain('## Instructions');
+    expect(result).toContain('Read the code');
+    expect(result).toContain('Write tests');
+    expect(result).toContain('Run the tests');
+    expect(result).toContain('Report results');
+  });
+
+  it('includes feature skills', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [
+          { name: 'Fly', prompt: 'Make it fly', category: 'feature' },
+        ],
+      },
+    });
+    expect(result).toContain("## Detailed Feature Instructions (kid's skills)");
+    expect(result).toContain('<kid_skill name="Fly">');
+    expect(result).toContain('Make it fly');
+  });
+
+  it('includes style skills', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        skills: [
+          { name: 'Rainbow', prompt: 'Make it rainbow', category: 'style' },
+        ],
+      },
+    });
+    expect(result).toContain("## Detailed Style Instructions (kid's skills)");
+    expect(result).toContain('<kid_skill name="Rainbow">');
+  });
+
+  it('includes on_task_complete rules only', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        rules: [
+          { name: 'Validate', prompt: 'Check output', trigger: 'on_task_complete' },
+          { name: 'Pre-deploy', prompt: 'Lint check', trigger: 'before_deploy' },
+        ],
+      },
+    });
+    expect(result).toContain("## Validation Rules (kid's rules)");
+    expect(result).toContain('<kid_rule name="Validate">');
+    expect(result).not.toContain('Pre-deploy');
+  });
+
+  it('omits skills/rules sections when missing from spec', () => {
+    const result = formatTaskPrompt(baseParams);
+    expect(result).not.toContain("kid's skills");
+    expect(result).not.toContain("kid's rules");
+  });
+
+  it('does NOT include portals (tester has no portal section)', () => {
+    const result = formatTaskPrompt({
+      ...baseParams,
+      spec: {
+        ...baseParams.spec,
+        portals: [{ name: 'api', description: 'An API', mechanism: 'mcp' }],
+      },
+    });
+    expect(result).not.toContain('## Available Portals');
+  });
+});


### PR DESCRIPTION
## Summary

- Add 142 unit tests across 5 test files covering all backend prompts modules
- Achieve 100% statement, branch, function, and line coverage (up from 43%)
- Tests cover: `builderAgent`, `testerAgent`, `reviewerAgent`, `metaPlanner`, and `teaching`

Key areas tested:
- `formatTaskPrompt()` edge cases: missing context, empty arrays, skill/rule filtering by category, portal context injection with capabilities/interactions
- `buildMetaPlannerSystem()` conditional sections: hardware, portals, deployment target detection
- `formatStyle()` current vs legacy fields, empty style fallback
- Teaching curriculum lookup, edge cases for unknown concepts, `teachingUserPrompt` formatting
- `metaPlannerUser()` JSON wrapping

## Test plan

- [x] All 142 tests pass (`npx vitest run src/prompts/`)
- [x] 100% coverage on all 5 prompts files (`npx vitest run src/prompts/ --coverage`)
- [x] No changes to source code -- tests only

Closes #24