### PR TITLE
Wire CLI portal execution into deploy phase

### DIFF
--- a/backend/src/services/phases/deployPhase.cli.test.ts
+++ b/backend/src/services/phases/deployPhase.cli.test.ts
@@ -1,0 +1,181 @@
+/** Tests for CLI portal deployment in DeployPhase. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DeployPhase } from './deployPhase.js';
+import type { PhaseContext } from './types.js';
+import type { CliExecResult } from '../portalService.js';
+
+function makeCtx(overrides: Partial<PhaseContext> = {}): PhaseContext {
+  return {
+    session: { id: 'test', state: 'executing', spec: {} } as any,
+    send: vi.fn().mockResolvedValue(undefined),
+    logger: null,
+    nuggetDir: '/tmp/test-nugget',
+    nuggetType: 'software',
+    abortSignal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+function makeMockHardwareService() {
+  return {
+    compile: vi.fn(),
+    flash: vi.fn(),
+    detectBoard: vi.fn(),
+    startSerialMonitor: vi.fn(),
+  } as any;
+}
+
+function makeMockPortalService(options: {
+  hasSerial?: boolean;
+  cliPortals?: Array<{
+    name: string;
+    executeResult: CliExecResult;
+  }>;
+} = {}) {
+  const cliPortals = (options.cliPortals ?? []).map(({ name, executeResult }) => ({
+    name,
+    adapter: {
+      execute: vi.fn().mockResolvedValue(executeResult),
+      getCommand: () => 'test-cmd',
+      getArgs: () => [],
+      getCapabilities: () => [],
+      initialize: vi.fn(),
+      teardown: vi.fn(),
+    },
+  }));
+
+  return {
+    hasSerialPortals: vi.fn().mockReturnValue(options.hasSerial ?? false),
+    getCliPortals: vi.fn().mockReturnValue(cliPortals),
+    getMcpServers: vi.fn().mockReturnValue([]),
+    teardownAll: vi.fn().mockResolvedValue(undefined),
+    initializePortals: vi.fn().mockResolvedValue(undefined),
+    getAllRuntimes: vi.fn().mockReturnValue([]),
+    getRuntime: vi.fn(),
+  } as any;
+}
+
+function makeMockTeachingEngine() {
+  return {
+    getMoment: vi.fn().mockResolvedValue(null),
+    getShownConcepts: vi.fn().mockReturnValue([]),
+  } as any;
+}
+
+describe('DeployPhase.deployPortals - CLI portals', () => {
+  let hw: ReturnType<typeof makeMockHardwareService>;
+  let teachingEngine: ReturnType<typeof makeMockTeachingEngine>;
+
+  beforeEach(() => {
+    hw = makeMockHardwareService();
+    teachingEngine = makeMockTeachingEngine();
+  });
+
+  it('executes CLI portals and sends progress events', async () => {
+    const portalService = makeMockPortalService({
+      cliPortals: [
+        { name: 'lint', executeResult: { success: true, stdout: 'All clean', stderr: '' } },
+      ],
+    });
+    const phase = new DeployPhase(hw, portalService, teachingEngine);
+    const ctx = makeCtx();
+
+    await phase.deployPortals(ctx);
+
+    const send = ctx.send as ReturnType<typeof vi.fn>;
+    const calls = send.mock.calls.map((c: any[]) => c[0]);
+
+    // Should have deploy_started, deploy_progress for running, deploy_progress for stdout, deploy_complete
+    expect(calls[0]).toEqual({ type: 'deploy_started', target: 'portals' });
+    expect(calls.some((c: any) => c.type === 'deploy_progress' && c.step.includes('Running CLI portal "lint"'))).toBe(true);
+    expect(calls.some((c: any) => c.type === 'deploy_progress' && c.step === 'All clean')).toBe(true);
+    expect(calls[calls.length - 1]).toEqual({ type: 'deploy_complete', target: 'portals' });
+
+    // Adapter.execute was called with nuggetDir
+    const adapter = portalService.getCliPortals()[0].adapter;
+    expect(adapter.execute).toHaveBeenCalledWith('/tmp/test-nugget');
+  });
+
+  it('sends error event when CLI portal fails', async () => {
+    const portalService = makeMockPortalService({
+      cliPortals: [
+        { name: 'deploy-tool', executeResult: { success: false, stdout: '', stderr: 'Permission denied' } },
+      ],
+    });
+    const phase = new DeployPhase(hw, portalService, teachingEngine);
+    const ctx = makeCtx();
+
+    await phase.deployPortals(ctx);
+
+    const send = ctx.send as ReturnType<typeof vi.fn>;
+    const calls = send.mock.calls.map((c: any[]) => c[0]);
+
+    const errorEvent = calls.find((c: any) => c.type === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent.message).toContain('deploy-tool');
+    expect(errorEvent.message).toContain('Permission denied');
+    expect(errorEvent.recoverable).toBe(true);
+
+    // Should still send deploy_complete even after failure
+    expect(calls[calls.length - 1]).toEqual({ type: 'deploy_complete', target: 'portals' });
+  });
+
+  it('handles multiple CLI portals sequentially', async () => {
+    const portalService = makeMockPortalService({
+      cliPortals: [
+        { name: 'first', executeResult: { success: true, stdout: 'done1', stderr: '' } },
+        { name: 'second', executeResult: { success: true, stdout: 'done2', stderr: '' } },
+      ],
+    });
+    const phase = new DeployPhase(hw, portalService, teachingEngine);
+    const ctx = makeCtx();
+
+    await phase.deployPortals(ctx);
+
+    const send = ctx.send as ReturnType<typeof vi.fn>;
+    const calls = send.mock.calls.map((c: any[]) => c[0]);
+
+    const runningSteps = calls.filter(
+      (c: any) => c.type === 'deploy_progress' && c.step?.includes('Running CLI portal'),
+    );
+    expect(runningSteps).toHaveLength(2);
+    expect(runningSteps[0].step).toContain('first');
+    expect(runningSteps[1].step).toContain('second');
+  });
+
+  it('does not send stdout progress when stdout is empty', async () => {
+    const portalService = makeMockPortalService({
+      cliPortals: [
+        { name: 'quiet', executeResult: { success: true, stdout: '', stderr: '' } },
+      ],
+    });
+    const phase = new DeployPhase(hw, portalService, teachingEngine);
+    const ctx = makeCtx();
+
+    await phase.deployPortals(ctx);
+
+    const send = ctx.send as ReturnType<typeof vi.fn>;
+    const calls = send.mock.calls.map((c: any[]) => c[0]);
+
+    // Should only have: deploy_started, running progress, deploy_complete
+    const progressCalls = calls.filter((c: any) => c.type === 'deploy_progress');
+    expect(progressCalls).toHaveLength(1); // Only the "Running CLI portal" one
+    expect(progressCalls[0].step).toContain('Running CLI portal');
+  });
+
+  it('skips CLI execution when no CLI portals exist', async () => {
+    const portalService = makeMockPortalService({ cliPortals: [] });
+    const phase = new DeployPhase(hw, portalService, teachingEngine);
+    const ctx = makeCtx();
+
+    await phase.deployPortals(ctx);
+
+    const send = ctx.send as ReturnType<typeof vi.fn>;
+    const calls = send.mock.calls.map((c: any[]) => c[0]);
+
+    expect(calls).toHaveLength(2); // deploy_started + deploy_complete
+    expect(calls[0]).toEqual({ type: 'deploy_started', target: 'portals' });
+    expect(calls[calls.length - 1]).toEqual({ type: 'deploy_complete', target: 'portals' });
+  });
+});

--- a/backend/src/services/portalService.cli.test.ts
+++ b/backend/src/services/portalService.cli.test.ts
@@ -1,0 +1,184 @@
+/** Tests for CliPortalAdapter.execute() and PortalService.getCliPortals(). */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Track mock calls and configure results
+let mockExecFileCalls: any[][] = [];
+let execFileResult: { err: any; stdout: string; stderr: string } = {
+  err: null,
+  stdout: '',
+  stderr: '',
+};
+
+vi.mock('node:child_process', async () => {
+  const { promisify: realPromisify } = await import('node:util');
+
+  function mockExecFile(...args: any[]) {
+    mockExecFileCalls.push(args);
+    const cb = args[args.length - 1];
+    if (typeof cb === 'function') {
+      cb(execFileResult.err, execFileResult.stdout, execFileResult.stderr);
+    }
+  }
+
+  // promisify(execFile) uses the [util.promisify.custom] symbol
+  (mockExecFile as any)[realPromisify.custom] = (...args: any[]) => {
+    mockExecFileCalls.push(args);
+    if (execFileResult.err) {
+      const err = execFileResult.err;
+      err.stdout = err.stdout ?? execFileResult.stdout;
+      err.stderr = err.stderr ?? execFileResult.stderr;
+      return Promise.reject(err);
+    }
+    return Promise.resolve({
+      stdout: execFileResult.stdout,
+      stderr: execFileResult.stderr,
+    });
+  };
+
+  return { execFile: mockExecFile };
+});
+
+// Import after mock registration
+const { CliPortalAdapter, PortalService } = await import('./portalService.js');
+
+describe('CliPortalAdapter', () => {
+  beforeEach(() => {
+    mockExecFileCalls = [];
+    execFileResult = { err: null, stdout: '', stderr: '' };
+  });
+
+  it('returns failure when no command is configured', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({});
+
+    const result = await adapter.execute('/tmp/test');
+    expect(result.success).toBe(false);
+    expect(result.stderr).toBe('No command configured');
+    expect(mockExecFileCalls).toHaveLength(0);
+  });
+
+  it('executes command and returns stdout/stderr on success', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({ command: 'echo', args: ['hello'] });
+
+    execFileResult = { err: null, stdout: 'hello\n', stderr: '' };
+
+    const result = await adapter.execute('/tmp/test');
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe('hello\n');
+    expect(result.stderr).toBe('');
+    expect(mockExecFileCalls).toHaveLength(1);
+    expect(mockExecFileCalls[0][0]).toBe('echo');
+    expect(mockExecFileCalls[0][1]).toEqual(['hello']);
+  });
+
+  it('returns failure when command throws', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({ command: 'badcmd' });
+
+    const err = new Error('ENOENT') as any;
+    err.stdout = '';
+    err.stderr = 'not found';
+    execFileResult = { err, stdout: '', stderr: 'not found' };
+
+    const result = await adapter.execute('/tmp/test');
+    expect(result.success).toBe(false);
+    expect(result.stderr).toBe('not found');
+  });
+
+  it('passes cwd and timeout to execFile', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({ command: 'ls' });
+
+    execFileResult = { err: null, stdout: '', stderr: '' };
+
+    await adapter.execute('/my/dir', 5000);
+    expect(mockExecFileCalls).toHaveLength(1);
+    const opts = mockExecFileCalls[0][2];
+    expect(opts.cwd).toBe('/my/dir');
+    expect(opts.timeout).toBe(5000);
+  });
+
+  it('merges env when provided', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({
+      command: 'node',
+      env: { MY_VAR: 'hello' },
+    });
+
+    execFileResult = { err: null, stdout: '', stderr: '' };
+
+    await adapter.execute('/tmp/test');
+    const opts = mockExecFileCalls[0][2];
+    expect(opts.env).toBeDefined();
+    expect(opts.env.MY_VAR).toBe('hello');
+  });
+
+  it('does not set env when none provided', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({ command: 'ls' });
+
+    execFileResult = { err: null, stdout: '', stderr: '' };
+
+    await adapter.execute('/tmp/test');
+    const opts = mockExecFileCalls[0][2];
+    expect(opts.env).toBeUndefined();
+  });
+
+  it('stores and returns args via getArgs()', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({ command: 'git', args: ['status', '--short'] });
+
+    expect(adapter.getArgs()).toEqual(['status', '--short']);
+  });
+
+  it('defaults args to empty array', async () => {
+    const adapter = new CliPortalAdapter([]);
+    await adapter.initialize({ command: 'ls' });
+
+    expect(adapter.getArgs()).toEqual([]);
+  });
+});
+
+describe('PortalService.getCliPortals', () => {
+  it('returns only CLI portals', async () => {
+    const mockHw = {} as any;
+    const service = new PortalService(mockHw);
+
+    await service.initializePortals([
+      {
+        id: 'cli-1',
+        name: 'My CLI Tool',
+        description: 'test',
+        mechanism: 'cli',
+        capabilities: [],
+        interactions: [],
+        cliConfig: { command: 'mytool' },
+      },
+      {
+        id: 'mcp-1',
+        name: 'MCP Server',
+        description: 'test',
+        mechanism: 'mcp',
+        capabilities: [],
+        interactions: [],
+        mcpConfig: { command: 'mcp-server' },
+      },
+    ]);
+
+    const cliPortals = service.getCliPortals();
+    expect(cliPortals).toHaveLength(1);
+    expect(cliPortals[0].name).toBe('My CLI Tool');
+    expect(cliPortals[0].adapter.getCommand()).toBe('mytool');
+  });
+
+  it('returns empty array when no CLI portals exist', async () => {
+    const mockHw = {} as any;
+    const service = new PortalService(mockHw);
+
+    await service.initializePortals([]);
+
+    expect(service.getCliPortals()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `execute()` method to `CliPortalAdapter` using `execFile` (no shell) to prevent command injection
- Extends `CliPortalAdapter` with `args`/`env` fields and `getArgs()` accessor
- Adds `getCliPortals()` to `PortalService` to collect CLI portal adapters
- Adds CLI portal execution loop in `DeployPhase.deployPortals()` after serial portals
- Streams stdout via `deploy_progress` events, reports failures via recoverable `error` events

## Test plan
- [x] 10 unit tests for `CliPortalAdapter.execute()` (success, failure, no command, cwd/timeout, env merge, args)
- [x] 5 integration tests for `DeployPhase.deployPortals()` CLI path (progress events, error events, multiple portals, empty stdout, no CLI portals)
- [x] All 263 existing backend tests still pass

Closes #27