### PR TITLE
Add comprehensive tests for frontend Skills module

### DIFF
--- a/frontend/src/components/Skills/SkillQuestionModal.test.tsx
+++ b/frontend/src/components/Skills/SkillQuestionModal.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import SkillQuestionModal from './SkillQuestionModal';
+import type { QuestionPayload } from '../../types';
+
+// Mock global fetch
+const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+vi.stubGlobal('fetch', mockFetch);
+
+const singleSelectQuestion: QuestionPayload = {
+  header: 'Color Theme',
+  question: 'What color theme do you want?',
+  multiSelect: false,
+  options: [
+    { label: 'Dark', description: 'Dark background with light text' },
+    { label: 'Light', description: 'Light background with dark text' },
+  ],
+};
+
+const multiSelectQuestion: QuestionPayload = {
+  header: 'Features',
+  question: 'Which features do you want?',
+  multiSelect: true,
+  options: [
+    { label: 'Animations', description: 'Smooth transitions' },
+    { label: 'Sound', description: 'Audio feedback' },
+    { label: 'Haptics' },
+  ],
+};
+
+const defaultProps = {
+  stepId: 'step-1',
+  sessionId: 'session-abc',
+  onClose: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetch.mockResolvedValue({ ok: true });
+});
+
+describe('SkillQuestionModal', () => {
+  it('renders the modal title', () => {
+    render(<SkillQuestionModal {...defaultProps} questions={[singleSelectQuestion]} />);
+    expect(screen.getByText('Skill needs your input')).toBeInTheDocument();
+  });
+
+  it('renders radio buttons for single-select question', () => {
+    render(<SkillQuestionModal {...defaultProps} questions={[singleSelectQuestion]} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+    expect(screen.getByText('Dark')).toBeInTheDocument();
+    expect(screen.getByText('Light')).toBeInTheDocument();
+  });
+
+  it('renders checkboxes for multi-select question', () => {
+    render(<SkillQuestionModal {...defaultProps} questions={[multiSelectQuestion]} />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(3);
+    expect(screen.getByText('Animations')).toBeInTheDocument();
+    expect(screen.getByText('Sound')).toBeInTheDocument();
+    expect(screen.getByText('Haptics')).toBeInTheDocument();
+  });
+
+  it('selects a radio option on click', () => {
+    render(<SkillQuestionModal {...defaultProps} questions={[singleSelectQuestion]} />);
+    const radios = screen.getAllByRole('radio');
+    fireEvent.click(radios[0]);
+    expect(radios[0]).toBeChecked();
+    expect(radios[1]).not.toBeChecked();
+  });
+
+  it('toggles checkbox options on click', () => {
+    render(<SkillQuestionModal {...defaultProps} questions={[multiSelectQuestion]} />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).toBeChecked();
+    fireEvent.click(checkboxes[1]);
+    expect(checkboxes[1]).toBeChecked();
+    // Uncheck first
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+  });
+
+  it('submits single-select answer and calls onClose', async () => {
+    const onClose = vi.fn();
+    render(
+      <SkillQuestionModal
+        {...defaultProps}
+        questions={[singleSelectQuestion]}
+        onClose={onClose}
+      />,
+    );
+    const radios = screen.getAllByRole('radio');
+    fireEvent.click(radios[1]); // Select "Light"
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/skills/session-abc/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          step_id: 'step-1',
+          answers: { 'Color Theme': 'Light' },
+        }),
+      });
+    });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('submits multi-select answers', async () => {
+    const onClose = vi.fn();
+    render(
+      <SkillQuestionModal
+        {...defaultProps}
+        questions={[multiSelectQuestion]}
+        onClose={onClose}
+      />,
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]); // Animations
+    fireEvent.click(checkboxes[2]); // Haptics
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith('/api/skills/session-abc/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          step_id: 'step-1',
+          answers: { Features: ['Animations', 'Haptics'] },
+        }),
+      });
+    });
+  });
+
+  it('renders multiple questions', () => {
+    render(
+      <SkillQuestionModal
+        {...defaultProps}
+        questions={[singleSelectQuestion, multiSelectQuestion]}
+      />,
+    );
+    expect(screen.getByText('What color theme do you want?')).toBeInTheDocument();
+    expect(screen.getByText('Which features do you want?')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+  });
+
+  it('disables submit button while submitting', async () => {
+    // Make fetch take time
+    let resolveFetch: () => void;
+    mockFetch.mockReturnValue(new Promise(r => { resolveFetch = () => r({ ok: true }); }));
+
+    render(<SkillQuestionModal {...defaultProps} questions={[singleSelectQuestion]} />);
+    const submitBtn = screen.getByText('Submit');
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => expect(submitBtn).toBeDisabled());
+    resolveFetch!();
+  });
+
+  it('renders option without description', () => {
+    render(<SkillQuestionModal {...defaultProps} questions={[multiSelectQuestion]} />);
+    // "Haptics" has no description
+    expect(screen.getByText('Haptics')).toBeInTheDocument();
+    // Verify the other options have their descriptions
+    expect(screen.getByText('Smooth transitions')).toBeInTheDocument();
+    expect(screen.getByText('Audio feedback')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Skills/SkillsRulesModal.test.tsx
+++ b/frontend/src/components/Skills/SkillsRulesModal.test.tsx
@@ -3,6 +3,21 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import SkillsRulesModal from './SkillsRulesModal';
 import type { Skill, Rule } from './types';
 
+// Mock SkillFlowEditor
+vi.mock('./SkillFlowEditor', () => ({
+  default: ({ skill, onSave, onClose }: {
+    skill: { name: string };
+    onSave: (workspace: Record<string, unknown>) => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid="mock-flow-editor">
+      <span>Flow Editor: {skill.name}</span>
+      <button onClick={() => onSave({ blocks: [] })}>Save Flow</button>
+      <button onClick={onClose}>Close Flow</button>
+    </div>
+  ),
+}));
+
 const defaultProps = {
   skills: [] as Skill[],
   rules: [] as Rule[],
@@ -18,6 +33,7 @@ beforeEach(() => {
 });
 
 describe('SkillsRulesModal', () => {
+  // --- Basic rendering ---
   it('renders with tabs', () => {
     render(<SkillsRulesModal {...defaultProps} />);
     expect(screen.getByText('Skills & Rules')).toBeInTheDocument();
@@ -36,6 +52,7 @@ describe('SkillsRulesModal', () => {
     expect(screen.getByText(/No rules yet/)).toBeInTheDocument();
   });
 
+  // --- Skill display ---
   it('displays existing skills', () => {
     const skills: Skill[] = [
       { id: 's1', name: 'Be Creative', prompt: 'Use bright colors', category: 'style' },
@@ -54,17 +71,49 @@ describe('SkillsRulesModal', () => {
     expect(screen.getByText('Always Comment')).toBeInTheDocument();
   });
 
+  it('counts skills and rules in tab labels', () => {
+    const skills: Skill[] = [
+      { id: 's1', name: 'S1', prompt: 'p', category: 'agent' },
+      { id: 's2', name: 'S2', prompt: 'p', category: 'feature' },
+    ];
+    const rules: Rule[] = [
+      { id: 'r1', name: 'R1', prompt: 'p', trigger: 'always' },
+    ];
+    render(<SkillsRulesModal {...defaultProps} skills={skills} rules={rules} />);
+    expect(screen.getByText('Skills (2)')).toBeInTheDocument();
+    expect(screen.getByText('Rules (1)')).toBeInTheDocument();
+  });
+
+  it('displays unnamed skill with fallback label', () => {
+    const skills: Skill[] = [
+      { id: 's1', name: '', prompt: 'some prompt', category: 'agent' },
+    ];
+    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    expect(screen.getByText('(unnamed)')).toBeInTheDocument();
+  });
+
+  it('truncates long prompt in skill list', () => {
+    const longPrompt = 'A'.repeat(100);
+    const skills: Skill[] = [
+      { id: 's1', name: 'Long', prompt: longPrompt, category: 'agent' },
+    ];
+    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    expect(screen.getByText(/A{80}\.\.\./)).toBeInTheDocument();
+  });
+
+  it('shows "visual flow" for composite skill in list', () => {
+    const skills: Skill[] = [
+      { id: 's1', name: 'Composite', prompt: 'desc', category: 'composite' },
+    ];
+    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    expect(screen.getByText(/visual flow/)).toBeInTheDocument();
+  });
+
+  // --- Skill editor ---
   it('opens skill editor when clicking New Skill', () => {
     render(<SkillsRulesModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
     expect(screen.getByPlaceholderText('e.g. Be Extra Creative')).toBeInTheDocument();
-  });
-
-  it('opens rule editor when clicking New Rule', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    fireEvent.click(screen.getByText('Rules (0)'));
-    fireEvent.click(screen.getByText('+ New Rule'));
-    expect(screen.getByPlaceholderText('e.g. Always Add Comments')).toBeInTheDocument();
   });
 
   it('saves a new skill', () => {
@@ -90,7 +139,48 @@ describe('SkillsRulesModal', () => {
     ]);
   });
 
-  it('deletes a skill', () => {
+  it('edits an existing skill', () => {
+    const skills: Skill[] = [
+      { id: 's1', name: 'Old Name', prompt: 'Old prompt', category: 'agent' },
+    ];
+    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    fireEvent.click(screen.getByText('Edit'));
+
+    const nameInput = screen.getByDisplayValue('Old Name');
+    expect(nameInput).toBeInTheDocument();
+
+    const promptTextarea = screen.getByDisplayValue('Old prompt');
+    expect(promptTextarea).toBeInTheDocument();
+  });
+
+  it('updates an existing skill', () => {
+    const skills: Skill[] = [
+      { id: 's1', name: 'Old Name', prompt: 'Old prompt', category: 'agent' },
+    ];
+    const onSkillsChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
+    fireEvent.click(screen.getByText('Edit'));
+
+    const nameInput = screen.getByDisplayValue('Old Name');
+    fireEvent.change(nameInput, { target: { value: 'New Name' } });
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(onSkillsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 's1', name: 'New Name', prompt: 'Old prompt' }),
+    ]);
+  });
+
+  it('cancels editing a skill', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+    expect(screen.getByPlaceholderText('e.g. Be Extra Creative')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByPlaceholderText('e.g. Be Extra Creative')).not.toBeInTheDocument();
+  });
+
+  it('deletes a skill from list', () => {
     const skills: Skill[] = [
       { id: 's1', name: 'Be Creative', prompt: 'Use bright colors', category: 'style' },
     ];
@@ -100,23 +190,251 @@ describe('SkillsRulesModal', () => {
     expect(onSkillsChange).toHaveBeenCalledWith([]);
   });
 
+  it('deletes a skill from editor', () => {
+    const skills: Skill[] = [
+      { id: 's1', name: 'To Delete', prompt: 'prompt', category: 'agent' },
+    ];
+    const onSkillsChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
+    fireEvent.click(screen.getByText('Edit'));
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onSkillsChange).toHaveBeenCalledWith([]);
+  });
+
+  it('disables Done when name is empty', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+    const doneBtn = screen.getByText('Done');
+    expect(doneBtn).toBeDisabled();
+  });
+
+  it('disables Done when prompt is empty for non-composite skill', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+
+    const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
+    fireEvent.change(nameInput, { target: { value: 'Has Name' } });
+
+    const doneBtn = screen.getByText('Done');
+    expect(doneBtn).toBeDisabled();
+  });
+
+  it('changes category via select', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+
+    const select = screen.getByDisplayValue('Agent behavior');
+    fireEvent.change(select, { target: { value: 'style' } });
+    expect(screen.getByDisplayValue('Style details')).toBeInTheDocument();
+  });
+
+  // --- Composite / Flow Editor ---
+  it('shows Open Flow Editor for composite category', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+
+    const select = screen.getByDisplayValue('Agent behavior');
+    fireEvent.change(select, { target: { value: 'composite' } });
+
+    expect(screen.getByText('Open Flow Editor')).toBeInTheDocument();
+  });
+
+  it('disables Open Flow Editor when name is empty', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+
+    const select = screen.getByDisplayValue('Agent behavior');
+    fireEvent.change(select, { target: { value: 'composite' } });
+
+    expect(screen.getByText('Open Flow Editor')).toBeDisabled();
+  });
+
+  it('opens flow editor when clicking Open Flow Editor', () => {
+    const onSkillsChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+
+    const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
+    fireEvent.change(nameInput, { target: { value: 'My Flow' } });
+
+    const select = screen.getByDisplayValue('Agent behavior');
+    fireEvent.change(select, { target: { value: 'composite' } });
+
+    fireEvent.click(screen.getByText('Open Flow Editor'));
+
+    expect(screen.getByTestId('mock-flow-editor')).toBeInTheDocument();
+    expect(screen.getByText('Flow Editor: My Flow')).toBeInTheDocument();
+  });
+
+  it('saves workspace from flow editor', () => {
+    const onSkillsChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+
+    const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
+    fireEvent.change(nameInput, { target: { value: 'My Flow' } });
+
+    const select = screen.getByDisplayValue('Agent behavior');
+    fireEvent.change(select, { target: { value: 'composite' } });
+
+    fireEvent.click(screen.getByText('Open Flow Editor'));
+    fireEvent.click(screen.getByText('Save Flow'));
+
+    expect(onSkillsChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: 'My Flow',
+        category: 'composite',
+        workspace: { blocks: [] },
+      }),
+    ]);
+  });
+
+  it('closes flow editor without saving', () => {
+    const onSkillsChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+
+    const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
+    fireEvent.change(nameInput, { target: { value: 'My Flow' } });
+
+    const select = screen.getByDisplayValue('Agent behavior');
+    fireEvent.change(select, { target: { value: 'composite' } });
+
+    fireEvent.click(screen.getByText('Open Flow Editor'));
+    fireEvent.click(screen.getByText('Close Flow'));
+
+    // Should be back to modal, not flow editor
+    expect(screen.queryByTestId('mock-flow-editor')).not.toBeInTheDocument();
+    expect(screen.getByText('Skills & Rules')).toBeInTheDocument();
+  });
+
+  it('shows flow configured indicator for skill with workspace', () => {
+    const skills: Skill[] = [
+      { id: 's1', name: 'Configured', prompt: '', category: 'composite', workspace: { blocks: [] } },
+    ];
+    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    fireEvent.click(screen.getByText('Edit'));
+    expect(screen.getByText('Flow has been configured.')).toBeInTheDocument();
+  });
+
+  // --- Rule editor ---
+  it('opens rule editor when clicking New Rule', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Rules (0)'));
+    fireEvent.click(screen.getByText('+ New Rule'));
+    expect(screen.getByPlaceholderText('e.g. Always Add Comments')).toBeInTheDocument();
+  });
+
+  it('saves a new rule', () => {
+    const onRulesChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Rules (0)'));
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const nameInput = screen.getByPlaceholderText('e.g. Always Add Comments');
+    fireEvent.change(nameInput, { target: { value: 'Test Rule' } });
+
+    const textareas = screen.getAllByRole('textbox');
+    const promptTextarea = textareas.find(el => el.tagName === 'TEXTAREA')!;
+    fireEvent.change(promptTextarea, { target: { value: 'Test rule prompt' } });
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(onRulesChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: 'Test Rule',
+        prompt: 'Test rule prompt',
+        trigger: 'always',
+      }),
+    ]);
+  });
+
+  it('edits an existing rule', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'Old Rule', prompt: 'Old rule prompt', trigger: 'always' },
+    ];
+    render(<SkillsRulesModal {...defaultProps} rules={rules} />);
+    fireEvent.click(screen.getByText('Rules (1)'));
+    fireEvent.click(screen.getByText('Edit'));
+
+    expect(screen.getByDisplayValue('Old Rule')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Old rule prompt')).toBeInTheDocument();
+  });
+
+  it('deletes a rule from the list', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'Delete Me', prompt: 'prompt', trigger: 'always' },
+    ];
+    const onRulesChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Rules (1)'));
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onRulesChange).toHaveBeenCalledWith([]);
+  });
+
+  it('deletes a rule from the editor', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'Delete Me', prompt: 'prompt', trigger: 'always' },
+    ];
+    const onRulesChange = vi.fn();
+    render(<SkillsRulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Rules (1)'));
+    fireEvent.click(screen.getByText('Edit'));
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onRulesChange).toHaveBeenCalledWith([]);
+  });
+
+  it('cancels editing a rule', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Rules (0)'));
+    fireEvent.click(screen.getByText('+ New Rule'));
+    expect(screen.getByPlaceholderText('e.g. Always Add Comments')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByPlaceholderText('e.g. Always Add Comments')).not.toBeInTheDocument();
+  });
+
+  it('changes rule trigger via select', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Rules (0)'));
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const select = screen.getByDisplayValue('Always on');
+    fireEvent.change(select, { target: { value: 'on_test_fail' } });
+    expect(screen.getByDisplayValue('On test fail')).toBeInTheDocument();
+  });
+
+  it('disables Done when rule name or prompt is empty', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('Rules (0)'));
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const doneBtn = screen.getByText('Done');
+    expect(doneBtn).toBeDisabled();
+
+    // Add name only
+    const nameInput = screen.getByPlaceholderText('e.g. Always Add Comments');
+    fireEvent.change(nameInput, { target: { value: 'Has Name' } });
+    expect(doneBtn).toBeDisabled();
+  });
+
+  // --- Tab switching ---
+  it('clears skill editor when switching to rules tab', () => {
+    render(<SkillsRulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Skill'));
+    expect(screen.getByPlaceholderText('e.g. Be Extra Creative')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Rules (0)'));
+    fireEvent.click(screen.getByText('Skills (0)'));
+    // Editor should be cleared, back to empty state
+    expect(screen.getByText(/No skills yet/)).toBeInTheDocument();
+  });
+
+  // --- Close ---
   it('calls onClose when X is clicked', () => {
     const onClose = vi.fn();
     render(<SkillsRulesModal {...defaultProps} onClose={onClose} />);
     fireEvent.click(screen.getByText('X'));
     expect(onClose).toHaveBeenCalled();
-  });
-
-  it('counts skills and rules in tab labels', () => {
-    const skills: Skill[] = [
-      { id: 's1', name: 'S1', prompt: 'p', category: 'agent' },
-      { id: 's2', name: 'S2', prompt: 'p', category: 'feature' },
-    ];
-    const rules: Rule[] = [
-      { id: 'r1', name: 'R1', prompt: 'p', trigger: 'always' },
-    ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} rules={rules} />);
-    expect(screen.getByText('Skills (2)')).toBeInTheDocument();
-    expect(screen.getByText('Rules (1)')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Skills/skillsRegistry.test.ts
+++ b/frontend/src/components/Skills/skillsRegistry.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  updateSkillOptions,
+  updateRuleOptions,
+  getCurrentSkills,
+  getCurrentRules,
+} from './skillsRegistry';
+import type { Skill, Rule } from './types';
+
+beforeEach(() => {
+  updateSkillOptions([]);
+  updateRuleOptions([]);
+});
+
+describe('skillsRegistry', () => {
+  describe('updateSkillOptions / getCurrentSkills', () => {
+    it('should return empty array initially', () => {
+      expect(getCurrentSkills()).toEqual([]);
+    });
+
+    it('should store and retrieve skills', () => {
+      const skills: Skill[] = [
+        { id: 's1', name: 'Creative', prompt: 'Be creative', category: 'style' },
+        { id: 's2', name: 'Fast', prompt: 'Be fast', category: 'agent' },
+      ];
+      updateSkillOptions(skills);
+      expect(getCurrentSkills()).toEqual(skills);
+    });
+
+    it('should replace previous skills on update', () => {
+      updateSkillOptions([{ id: 's1', name: 'Old', prompt: 'old', category: 'agent' }]);
+      const newSkills: Skill[] = [{ id: 's2', name: 'New', prompt: 'new', category: 'feature' }];
+      updateSkillOptions(newSkills);
+      expect(getCurrentSkills()).toEqual(newSkills);
+      expect(getCurrentSkills()).toHaveLength(1);
+    });
+
+    it('should clear skills when updated with empty array', () => {
+      updateSkillOptions([{ id: 's1', name: 'S', prompt: 'p', category: 'agent' }]);
+      updateSkillOptions([]);
+      expect(getCurrentSkills()).toEqual([]);
+    });
+  });
+
+  describe('updateRuleOptions / getCurrentRules', () => {
+    it('should return empty array initially', () => {
+      expect(getCurrentRules()).toEqual([]);
+    });
+
+    it('should store and retrieve rules', () => {
+      const rules: Rule[] = [
+        { id: 'r1', name: 'Comments', prompt: 'Add comments', trigger: 'always' },
+      ];
+      updateRuleOptions(rules);
+      expect(getCurrentRules()).toEqual(rules);
+    });
+
+    it('should replace previous rules on update', () => {
+      updateRuleOptions([{ id: 'r1', name: 'Old', prompt: 'old', trigger: 'always' }]);
+      const newRules: Rule[] = [{ id: 'r2', name: 'New', prompt: 'new', trigger: 'on_test_fail' }];
+      updateRuleOptions(newRules);
+      expect(getCurrentRules()).toEqual(newRules);
+    });
+  });
+
+  describe('independence', () => {
+    it('should track skills and rules independently', () => {
+      const skills: Skill[] = [{ id: 's1', name: 'S', prompt: 'p', category: 'agent' }];
+      const rules: Rule[] = [{ id: 'r1', name: 'R', prompt: 'p', trigger: 'always' }];
+      updateSkillOptions(skills);
+      updateRuleOptions(rules);
+      expect(getCurrentSkills()).toEqual(skills);
+      expect(getCurrentRules()).toEqual(rules);
+
+      updateSkillOptions([]);
+      expect(getCurrentSkills()).toEqual([]);
+      expect(getCurrentRules()).toEqual(rules);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `skillsRegistry.test.ts` (8 tests) covering state management: store/retrieve, replace, clear, independence between skills and rules
- Adds `SkillQuestionModal.test.tsx` (10 tests) covering single-select (radio), multi-select (checkbox), submit with API call verification, disabled state while submitting, options with/without descriptions
- Expands `SkillsRulesModal.test.tsx` from 11 to 35 tests covering full CRUD for skills and rules, composite flow editor integration (open/save/close), category/trigger changes, validation (disabled Done), tab switching state cleanup, unnamed skill display, long prompt truncation

Coverage raised from 57% to ~99% line coverage (53 total tests).

Closes #25

## Test plan

- [x] All 53 tests pass locally via `npx vitest run --reporter=verbose`
- [x] Coverage verified at 99% line coverage across Skills module
- [ ] CI passes on this PR