### PR TITLE
Surface Zod validation errors in frontend error banner

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -402,13 +402,13 @@ export default function App() {
       )}
 
       {/* Error notification banner */}
-      {errorNotification && !errorNotification.recoverable && (
+      {errorNotification && (
         <div className="fixed top-16 left-1/2 -translate-x-1/2 z-50 max-w-lg w-full mx-4 animate-float-in">
           <div className="glass-elevated rounded-xl border border-red-500/30 bg-red-950/40 px-5 py-3 flex items-start gap-3 shadow-lg">
             <span className="text-red-400 text-lg leading-none mt-0.5">!</span>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-red-200">Error</p>
-              <p className="text-sm text-red-300/80 mt-0.5 break-words">{errorNotification.message}</p>
+              <p className="text-sm text-red-300/80 mt-0.5 break-words whitespace-pre-line">{errorNotification.message}</p>
             </div>
             <button
               onClick={clearErrorNotification}

--- a/frontend/src/hooks/useBuildSession.ts
+++ b/frontend/src/hooks/useBuildSession.ts
@@ -230,9 +230,9 @@ export function useBuildSession() {
 
     const res = await fetch('/api/sessions', { method: 'POST' });
     if (!res.ok) {
-      const body = await res.json().catch(() => ({ error: res.statusText }));
+      const body = await res.json().catch(() => ({ detail: res.statusText }));
       setUiState('design');
-      setErrorNotification({ message: body.error || 'Failed to create session', recoverable: true, timestamp: Date.now() });
+      setErrorNotification({ message: body.detail || 'Failed to create session', recoverable: true, timestamp: Date.now() });
       return;
     }
     const { session_id } = await res.json();
@@ -249,9 +249,16 @@ export function useBuildSession() {
       body: JSON.stringify({ spec }),
     });
     if (!startRes.ok) {
-      const body = await startRes.json().catch(() => ({ error: startRes.statusText }));
+      const body = await startRes.json().catch(() => ({ detail: startRes.statusText }));
+      let message = body.detail || 'Failed to start build';
+      if (Array.isArray(body.errors) && body.errors.length > 0) {
+        const fieldErrors = body.errors.map((e: { path: string; message: string }) =>
+          e.path ? `${e.path}: ${e.message}` : e.message
+        );
+        message += '\n' + fieldErrors.join('\n');
+      }
       setUiState('design');
-      setErrorNotification({ message: body.error || 'Failed to start build', recoverable: true, timestamp: Date.now() });
+      setErrorNotification({ message, recoverable: true, timestamp: Date.now() });
     }
   }, []);
 


### PR DESCRIPTION
## Summary

- Fix field name mismatch: backend returns `{ detail, errors }` but frontend was reading `body.error`, causing validation errors to silently fall through to a generic message
- Parse `body.errors` array from Zod validation and append per-field messages (e.g., `nugget.goal: Required`)
- Show error banner for all errors, not just non-recoverable ones (validation errors are marked `recoverable: true`)
- Add `whitespace-pre-line` CSS class for multi-line error display

## Test plan

- [x] 4 new regression tests covering Zod error parsing, field name fix, session creation errors, and fallback behavior
- [x] All 223 frontend tests pass (25 files)
- [ ] Manual: Submit invalid NuggetSpec and verify per-field errors appear in the banner

Closes #20