### PR TITLE
Implement capability parameters in portal blocks

### DIFF
--- a/backend/src/prompts/builderAgent.ts
+++ b/backend/src/prompts/builderAgent.ts
@@ -159,7 +159,12 @@ export function formatTaskPrompt(params: {
       if (portal.interactions?.length) {
         portalParts.push('Requested interactions:');
         for (const interaction of portal.interactions) {
-          portalParts.push(`  - ${interaction.type}: ${interaction.capabilityId}`);
+          let interactionLine = `  - ${interaction.type}: ${interaction.capabilityId}`;
+          if (interaction.params && Object.keys(interaction.params).length > 0) {
+            const paramStr = Object.entries(interaction.params).map(([k, v]) => `${k}=${v}`).join(', ');
+            interactionLine += ` (${paramStr})`;
+          }
+          portalParts.push(interactionLine);
         }
       }
       parts.push(`<user_input name="portal:${portal.name}">\n${portalParts.join('\n')}\n</user_input>`);

--- a/backend/src/services/portalService.ts
+++ b/backend/src/services/portalService.ts
@@ -25,7 +25,7 @@ export interface PortalSpec {
   description: string;
   mechanism: string;
   capabilities: PortalCapability[];
-  interactions: Array<{ type: 'tell' | 'when' | 'ask'; capabilityId: string }>;
+  interactions: Array<{ type: 'tell' | 'when' | 'ask'; capabilityId: string; params?: Record<string, string | number | boolean> }>;
   mcpConfig?: Record<string, unknown>;
   cliConfig?: Record<string, unknown>;
   serialConfig?: Record<string, unknown>;

--- a/backend/src/utils/specValidator.test.ts
+++ b/backend/src/utils/specValidator.test.ts
@@ -161,3 +161,171 @@ describe('NuggetSpecSchema portal config validation', () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe('NuggetSpecSchema basic validation', () => {
+  it('accepts minimal valid spec', () => {
+    const result = NuggetSpecSchema.safeParse({
+      nugget: { goal: 'Build a game' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty object', () => {
+    const result = NuggetSpecSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects goal exceeding max length', () => {
+    const result = NuggetSpecSchema.safeParse({
+      nugget: { goal: 'x'.repeat(2001) },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('portal interaction params', () => {
+  it('accepts interaction without params', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'serial',
+        interactions: [{ type: 'tell', capabilityId: 'led-on' }],
+      }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts interaction with string params', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'serial',
+        interactions: [{
+          type: 'tell',
+          capabilityId: 'led-on',
+          params: { color: 'red', message: 'hello' },
+        }],
+      }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts interaction with number params', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'mcp',
+        interactions: [{
+          type: 'ask',
+          capabilityId: 'read-temp',
+          params: { interval: 5, threshold: 25.5 },
+        }],
+      }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts interaction with boolean params', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'cli',
+        interactions: [{
+          type: 'tell',
+          capabilityId: 'toggle',
+          params: { enabled: true, verbose: false },
+        }],
+      }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts interaction with mixed param types', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Mixed Portal',
+        description: 'desc',
+        mechanism: 'serial',
+        interactions: [{
+          type: 'tell',
+          capabilityId: 'led-on',
+          params: { color: 'blue', brightness: 80, blinking: true },
+        }],
+      }],
+    });
+    expect(result.success).toBe(true);
+    const parsed = result.data!;
+    const params = parsed.portals![0].interactions![0].params!;
+    expect(params.color).toBe('blue');
+    expect(params.brightness).toBe(80);
+    expect(params.blinking).toBe(true);
+  });
+
+  it('accepts empty params object', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'serial',
+        interactions: [{
+          type: 'tell',
+          capabilityId: 'led-on',
+          params: {},
+        }],
+      }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects param value exceeding max string length', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'serial',
+        interactions: [{
+          type: 'tell',
+          capabilityId: 'led-on',
+          params: { data: 'x'.repeat(2001) },
+        }],
+      }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects param key exceeding max length', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'serial',
+        interactions: [{
+          type: 'tell',
+          capabilityId: 'led-on',
+          params: { ['k'.repeat(201)]: 'value' },
+        }],
+      }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-primitive param values (object)', () => {
+    const result = NuggetSpecSchema.safeParse({
+      portals: [{
+        name: 'Test Portal',
+        description: 'desc',
+        mechanism: 'serial',
+        interactions: [{
+          type: 'tell',
+          capabilityId: 'led-on',
+          params: { nested: { bad: true } },
+        }],
+      }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/utils/specValidator.ts
+++ b/backend/src/utils/specValidator.ts
@@ -12,6 +12,7 @@ const CapabilitySchema = z.object({
 const InteractionSchema = z.object({
   type: z.string().max(100).optional(),
   capabilityId: z.string().max(200).optional(),
+  params: z.record(z.string().max(200), z.union([z.string().max(2000), z.number(), z.boolean()])).optional(),
 }).passthrough();
 
 /** Shell metacharacters forbidden in portal args. */


### PR DESCRIPTION
## Summary

- Portal capabilities can now define typed parameters (string, number, boolean, choice) via the existing `PortalParam` type
- Blockly portal blocks dynamically render input fields (text, number, checkbox, dropdown) when a capability with params is selected
- Block interpreter extracts param values from `PARAM_*` fields with type coercion and default value support
- Zod schema validates params as `Record<string, string | number | boolean>`
- Builder agent prompt includes param values in portal interaction context

## Changed files

| File | Change |
|------|--------|
| `backend/src/utils/specValidator.ts` | Add `params` to InteractionSchema |
| `backend/src/services/portalService.ts` | Add `params` to PortalSpec interaction type |
| `backend/src/prompts/builderAgent.ts` | Format params in portal interaction prompt |
| `frontend/src/components/BlockCanvas/blockDefinitions.ts` | Dynamic param inputs via validators |
| `frontend/src/components/BlockCanvas/blockInterpreter.ts` | Extract and coerce param values |

## Test plan

- [x] 12 new specValidator tests (params validation, type checks, length limits, rejection)
- [x] 7 new blockInterpreter tests (param extraction, defaults, type coercion, edge cases)
- [x] All 40 existing blockInterpreter tests pass (no regressions)
- [x] Frontend TypeScript compiles cleanly
- [x] Backward compatible -- params field is optional throughout

Closes #29