### PR TITLE
Add session persistence with checkpoint/recovery

### DIFF
--- a/backend/src/services/sessionStore.test.ts
+++ b/backend/src/services/sessionStore.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionStore } from './sessionStore.js';
+import type { BuildSession } from '../models/session.js';
+
+// Mock SessionPersistence
+const mockCheckpoint = vi.fn();
+const mockLoadAll = vi.fn().mockReturnValue([]);
+const mockRemove = vi.fn();
+const mockClear = vi.fn();
+
+vi.mock('../utils/sessionPersistence.js', () => ({
+  SessionPersistence: vi.fn().mockImplementation(() => ({
+    checkpoint: mockCheckpoint,
+    load: vi.fn(),
+    loadAll: mockLoadAll,
+    remove: mockRemove,
+    clear: mockClear,
+  })),
+}));
+
+function makeSession(id: string, state: BuildSession['state'] = 'idle'): BuildSession {
+  return { id, state, spec: null, tasks: [], agents: [] };
+}
+
+describe('SessionStore persistence integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadAll.mockReturnValue([]);
+  });
+
+  it('checkpoints on create', () => {
+    const store = new SessionStore();
+    store.create('s1', makeSession('s1'));
+    expect(mockCheckpoint).toHaveBeenCalledWith(expect.objectContaining({ id: 's1' }));
+  });
+
+  it('checkpoint is callable manually', () => {
+    const store = new SessionStore();
+    store.create('s1', makeSession('s1'));
+    mockCheckpoint.mockClear();
+    const entry = store.get('s1')!;
+    entry.session.state = 'executing';
+    store.checkpoint('s1');
+    expect(mockCheckpoint).toHaveBeenCalledWith(expect.objectContaining({ id: 's1', state: 'executing' }));
+  });
+
+  it('checkpoint ignores missing sessions', () => {
+    const store = new SessionStore();
+    store.checkpoint('nonexistent');
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it('checkpoint swallows persistence errors', () => {
+    const store = new SessionStore();
+    mockCheckpoint.mockImplementationOnce(() => { throw new Error('disk full'); });
+    expect(() => store.create('s1', makeSession('s1'))).not.toThrow();
+  });
+
+  it('recovers persisted sessions on startup', () => {
+    mockLoadAll.mockReturnValue([
+      { session: makeSession('r1', 'executing'), savedAt: Date.now() - 1000 },
+      { session: makeSession('r2', 'done'), savedAt: Date.now() - 2000 },
+    ]);
+    const store = new SessionStore();
+    const count = store.recover();
+    expect(count).toBe(2);
+    expect(store.size).toBe(2);
+    // Active sessions are marked done (can't restore orchestrators)
+    expect(store.get('r1')!.session.state).toBe('done');
+    expect(store.get('r2')!.session.state).toBe('done');
+  });
+
+  it('recover skips sessions already in memory', () => {
+    mockLoadAll.mockReturnValue([
+      { session: makeSession('s1', 'idle'), savedAt: Date.now() },
+    ]);
+    const store = new SessionStore();
+    store.create('s1', makeSession('s1'));
+    const count = store.recover();
+    expect(count).toBe(0);
+    expect(store.size).toBe(1);
+  });
+
+  it('recover preserves idle sessions as idle', () => {
+    mockLoadAll.mockReturnValue([
+      { session: makeSession('r1', 'idle'), savedAt: Date.now() },
+    ]);
+    const store = new SessionStore();
+    const count = store.recover();
+    expect(count).toBe(1);
+    expect(store.get('r1')!.session.state).toBe('idle');
+  });
+
+  it('recover swallows errors', () => {
+    mockLoadAll.mockImplementationOnce(() => { throw new Error('corrupt'); });
+    const store = new SessionStore();
+    expect(store.recover()).toBe(0);
+  });
+
+  it('removes persistence file on cleanup', () => {
+    vi.useFakeTimers();
+    const store = new SessionStore();
+    store.create('s1', makeSession('s1'));
+    store.scheduleCleanup('s1', 100);
+    vi.advanceTimersByTime(100);
+    expect(mockRemove).toHaveBeenCalledWith('s1');
+    vi.useRealTimers();
+  });
+
+  it('removes persistence file on pruneStale', () => {
+    const store = new SessionStore();
+    store.create('s1', makeSession('s1'));
+    // Force entry to be stale
+    const entry = store.get('s1')!;
+    entry.createdAt = Date.now() - 7_200_000; // 2 hours ago
+    store.pruneStale(3_600_000);
+    expect(mockRemove).toHaveBeenCalledWith('s1');
+  });
+
+  it('disables persistence when false is passed', () => {
+    const store = new SessionStore(false);
+    store.create('s1', makeSession('s1'));
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+    expect(store.recover()).toBe(0);
+  });
+});

--- a/backend/src/utils/sessionPersistence.test.ts
+++ b/backend/src/utils/sessionPersistence.test.ts
@@ -1,0 +1,144 @@
+/** Tests for SessionPersistence. */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SessionPersistence } from './sessionPersistence.js';
+import type { BuildSession } from '../models/session.js';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'elisa-persist-test-'));
+}
+
+function makeSession(overrides: Partial<BuildSession> = {}): BuildSession {
+  return {
+    id: 'test-session-1',
+    state: 'executing',
+    spec: { goal: 'test' },
+    tasks: [{ id: 't1', name: 'Task 1', status: 'done' }],
+    agents: [{ name: 'builder', role: 'builder', status: 'idle' }],
+    ...overrides,
+  };
+}
+
+describe('SessionPersistence', () => {
+  let dir: string;
+  let persistence: SessionPersistence;
+
+  beforeEach(() => {
+    dir = makeTempDir();
+    persistence = new SessionPersistence(dir);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  it('checkpoints and loads a session', () => {
+    const session = makeSession();
+    persistence.checkpoint(session);
+
+    const loaded = persistence.load('test-session-1');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.session.id).toBe('test-session-1');
+    expect(loaded!.session.state).toBe('executing');
+    expect(loaded!.phase).toBe('executing');
+    expect(loaded!.savedAt).toBeTruthy();
+  });
+
+  it('returns null for non-existent session', () => {
+    expect(persistence.load('nonexistent')).toBeNull();
+  });
+
+  it('overwrites previous checkpoint', () => {
+    const session = makeSession({ state: 'planning' });
+    persistence.checkpoint(session);
+
+    session.state = 'executing';
+    persistence.checkpoint(session);
+
+    const loaded = persistence.load('test-session-1');
+    expect(loaded!.session.state).toBe('executing');
+    expect(loaded!.phase).toBe('executing');
+  });
+
+  it('loadAll returns all persisted sessions', () => {
+    persistence.checkpoint(makeSession({ id: 'a' }));
+    persistence.checkpoint(makeSession({ id: 'b' }));
+    persistence.checkpoint(makeSession({ id: 'c' }));
+
+    const all = persistence.loadAll();
+    expect(all).toHaveLength(3);
+    const ids = all.map((s) => s.session.id).sort();
+    expect(ids).toEqual(['a', 'b', 'c']);
+  });
+
+  it('loadAll returns empty array when no sessions exist', () => {
+    expect(persistence.loadAll()).toEqual([]);
+  });
+
+  it('remove deletes the persisted file', () => {
+    persistence.checkpoint(makeSession());
+    expect(persistence.load('test-session-1')).not.toBeNull();
+
+    persistence.remove('test-session-1');
+    expect(persistence.load('test-session-1')).toBeNull();
+  });
+
+  it('remove does not throw for non-existent session', () => {
+    expect(() => persistence.remove('nonexistent')).not.toThrow();
+  });
+
+  it('clear removes all persisted files', () => {
+    persistence.checkpoint(makeSession({ id: 'x' }));
+    persistence.checkpoint(makeSession({ id: 'y' }));
+
+    persistence.clear();
+    expect(persistence.loadAll()).toEqual([]);
+  });
+
+  it('sanitizes session ID to prevent path traversal', () => {
+    const session = makeSession({ id: '../../../etc/passwd' });
+    persistence.checkpoint(session);
+
+    // File should be in the configured dir, not traversed
+    const files = fs.readdirSync(dir);
+    expect(files.length).toBe(1);
+    expect(files[0]).not.toContain('..');
+    expect(files[0]).toMatch(/\.json$/);
+  });
+
+  it('preserves task and agent data through checkpoint/load cycle', () => {
+    const session = makeSession({
+      tasks: [
+        { id: 't1', name: 'Build UI', status: 'done' },
+        { id: 't2', name: 'Write tests', status: 'in_progress' },
+      ],
+      agents: [
+        { name: 'builder-1', role: 'builder', status: 'working' },
+        { name: 'tester-1', role: 'tester', status: 'idle' },
+      ],
+    });
+    persistence.checkpoint(session);
+
+    const loaded = persistence.load('test-session-1')!;
+    expect(loaded.session.tasks).toHaveLength(2);
+    expect(loaded.session.agents).toHaveLength(2);
+    expect(loaded.session.tasks[1].status).toBe('in_progress');
+  });
+
+  it('skips corrupt files in loadAll', () => {
+    persistence.checkpoint(makeSession({ id: 'good' }));
+    // Write a corrupt file
+    fs.writeFileSync(path.join(dir, 'bad.json'), '{invalid json');
+
+    const all = persistence.loadAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].session.id).toBe('good');
+  });
+});

--- a/backend/src/utils/sessionPersistence.ts
+++ b/backend/src/utils/sessionPersistence.ts
@@ -1,0 +1,114 @@
+/** Persists session state to disk for crash recovery. */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { BuildSession } from '../models/session.js';
+
+export interface PersistedSession {
+  session: BuildSession;
+  savedAt: string;
+  phase: string;
+}
+
+const DEFAULT_DIR = path.join(os.tmpdir(), '.elisa-sessions');
+
+export class SessionPersistence {
+  private dir: string;
+
+  constructor(dir?: string) {
+    this.dir = dir ?? DEFAULT_DIR;
+  }
+
+  private ensureDir(): void {
+    if (!fs.existsSync(this.dir)) {
+      fs.mkdirSync(this.dir, { recursive: true });
+    }
+  }
+
+  private filePath(sessionId: string): string {
+    // Sanitize session ID to prevent path traversal
+    const safe = sessionId.replace(/[^a-zA-Z0-9\-]/g, '_');
+    return path.join(this.dir, `${safe}.json`);
+  }
+
+  /** Save session state to disk. */
+  checkpoint(session: BuildSession): void {
+    try {
+      this.ensureDir();
+      const data: PersistedSession = {
+        session,
+        savedAt: new Date().toISOString(),
+        phase: session.state,
+      };
+      const filePath = this.filePath(session.id);
+      const tmp = filePath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(data, null, 2));
+      fs.renameSync(tmp, filePath);
+    } catch (err) {
+      // Best-effort persistence -- don't crash the pipeline
+      console.warn('Session checkpoint failed:', (err as Error).message);
+    }
+  }
+
+  /** Load a single persisted session. */
+  load(sessionId: string): PersistedSession | null {
+    try {
+      const filePath = this.filePath(sessionId);
+      if (!fs.existsSync(filePath)) return null;
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      return JSON.parse(raw) as PersistedSession;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Load all persisted sessions from disk. */
+  loadAll(): PersistedSession[] {
+    try {
+      this.ensureDir();
+      const files = fs.readdirSync(this.dir).filter((f) => f.endsWith('.json'));
+      const sessions: PersistedSession[] = [];
+      for (const file of files) {
+        try {
+          const raw = fs.readFileSync(path.join(this.dir, file), 'utf-8');
+          sessions.push(JSON.parse(raw) as PersistedSession);
+        } catch {
+          // Skip corrupt files
+        }
+      }
+      return sessions;
+    } catch {
+      return [];
+    }
+  }
+
+  /** Remove persisted session file. */
+  remove(sessionId: string): void {
+    try {
+      const filePath = this.filePath(sessionId);
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
+  /** Remove all persisted session files. */
+  clear(): void {
+    try {
+      if (!fs.existsSync(this.dir)) return;
+      const files = fs.readdirSync(this.dir).filter((f) => f.endsWith('.json'));
+      for (const file of files) {
+        try {
+          fs.unlinkSync(path.join(this.dir, file));
+        } catch {
+          // ignore
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `SessionPersistence` utility that saves `BuildSession` state to JSON files on disk with atomic writes (temp file + rename) and path traversal protection
- Integrates persistence into `SessionStore`: auto-checkpoint on create, manual checkpoint for phase transitions, recovery on startup, cleanup on prune/scheduled removal
- Recovered in-flight sessions are marked `done` since orchestrators cannot be restored
- Persistence is opt-out via `new SessionStore(false)` for tests or ephemeral use
- 22 tests covering persistence layer (11) and store integration (11)

Closes #30

## Test plan

- [ ] `sessionPersistence.test.ts` -- 11 tests: checkpoint/load round-trip, overwrite, loadAll, remove, clear, path traversal rejection, data fidelity, corrupt file handling
- [ ] `sessionStore.test.ts` -- 11 tests: checkpoint on create, manual checkpoint, missing session handling, error swallowing, recovery of persisted sessions, skip duplicates, idle preservation, error tolerance, cleanup file removal, prune file removal, persistence disable