### PR TITLE
Add GitHub and Brave Search MCP portal templates

### DIFF
--- a/frontend/src/components/Portals/portalTemplates.ts
+++ b/frontend/src/components/Portals/portalTemplates.ts
@@ -40,4 +40,37 @@ export const portalTemplates: Omit<Portal, 'id'>[] = [
     mcpConfig: { command: 'npx', args: ['-y', '@anthropic-ai/mcp-filesystem'] },
     templateId: 'filesystem',
   },
+  {
+    name: 'GitHub',
+    description: 'Create issues, read repos, and search code on GitHub',
+    mechanism: 'mcp',
+    status: 'unconfigured',
+    capabilities: [
+      { id: 'create-issue', name: 'Create issue', kind: 'action', description: 'Create a new issue in a GitHub repository' },
+      { id: 'read-repo', name: 'Read repo', kind: 'query', description: 'Read files and metadata from a GitHub repository' },
+      { id: 'search-code', name: 'Search code', kind: 'query', description: 'Search for code across GitHub repositories' },
+    ],
+    mcpConfig: {
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-github'],
+      env: { GITHUB_PERSONAL_ACCESS_TOKEN: '' },
+    },
+    templateId: 'github',
+  },
+  {
+    name: 'Brave Search',
+    description: 'Search the web and find local businesses using Brave Search',
+    mechanism: 'mcp',
+    status: 'unconfigured',
+    capabilities: [
+      { id: 'web-search', name: 'Web search', kind: 'query', description: 'Search the web for information' },
+      { id: 'local-search', name: 'Local search', kind: 'query', description: 'Search for local businesses and places' },
+    ],
+    mcpConfig: {
+      command: 'npx',
+      args: ['-y', '@modelcontextprotocol/server-brave-search'],
+      env: { BRAVE_API_KEY: '' },
+    },
+    templateId: 'brave-search',
+  },
 ];


### PR DESCRIPTION
## Summary
- Add GitHub MCP template (create-issue, read-repo, search-code) via @modelcontextprotocol/server-github
- Add Brave Search MCP template (web-search, local-search) via @modelcontextprotocol/server-brave-search
- 15 tests covering template validation, uniqueness, config, and capabilities

Closes #28