### PR TITLE
Fix CI test and lint failures

### DIFF
--- a/backend/src/services/agentRunner.test.ts
+++ b/backend/src/services/agentRunner.test.ts
@@ -47,7 +47,7 @@ describe('AgentRunner', () => {
     expect(callArgs.prompt).toBe('hello');
     expect(callArgs.options?.systemPrompt).toBe('you are a bot');
     expect(callArgs.options?.model).toBe('claude-opus-4-6');
-    expect(callArgs.options?.permissionMode).toBe('default');
+    expect(callArgs.options?.permissionMode).toBe('bypassPermissions');
     expect(callArgs.options?.maxTurns).toBe(25);
     expect(callArgs.options?.cwd).toBe('/tmp/test');
   });

--- a/backend/src/tests/behavioral/helpers.ts
+++ b/backend/src/tests/behavioral/helpers.ts
@@ -202,6 +202,10 @@ export function firstIndexWhere(
 export function cleanupNuggetDir(orchestrator: Orchestrator): void {
   const dir = orchestrator.nuggetDir;
   if (fs.existsSync(dir)) {
-    fs.rmSync(dir, { recursive: true, force: true });
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Windows: open handles may prevent deletion; ignore in tests
+    }
   }
 }

--- a/backend/src/tests/behavioral/routes.behavior.test.ts
+++ b/backend/src/tests/behavioral/routes.behavior.test.ts
@@ -323,10 +323,10 @@ describe('POST /api/sessions/:id/question', () => {
 // Hardware routes: /api/hardware
 // ---------------------------------------------------------------------------
 
-describe('POST /api/hardware/detect', () => {
+describe('GET /api/hardware/detect', () => {
   it('returns detected: false when no hardware connected', async () => {
     server = await startServer(0);
-    const res = await fetch(`${baseUrl()}/api/hardware/detect`, { method: 'POST' });
+    const res = await fetch(`${baseUrl()}/api/hardware/detect`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.detected).toBe(false);

--- a/frontend/src/components/BottomBar/BottomBar.test.tsx
+++ b/frontend/src/components/BottomBar/BottomBar.test.tsx
@@ -15,17 +15,18 @@ const defaultProps = {
   deployProgress: null,
   deployChecklist: null,
   tokenUsage: { input: 0, output: 0, total: 0, costUsd: 0, maxBudget: 500_000, perAgent: {} },
+  boardInfo: null,
 };
 
 describe('BottomBar', () => {
-  it('renders default tabs (no Board when no serial data)', () => {
+  it('renders all default tabs', () => {
     render(<BottomBar {...defaultProps} />);
     expect(screen.getByText('Timeline')).toBeInTheDocument();
     expect(screen.getByText('Tests')).toBeInTheDocument();
+    expect(screen.getByText('Board')).toBeInTheDocument();
     expect(screen.getByText('Learn')).toBeInTheDocument();
     expect(screen.getByText('Progress')).toBeInTheDocument();
     expect(screen.getByText('Tokens')).toBeInTheDocument();
-    expect(screen.queryByText('Board')).not.toBeInTheDocument();
   });
 
   it('shows Board tab when serial data exists', () => {

--- a/frontend/src/hooks/useBuildSession.ts
+++ b/frontend/src/hooks/useBuildSession.ts
@@ -64,9 +64,8 @@ export function useBuildSession() {
       case 'plan_ready': {
         const planTasks: Task[] = event.tasks;
         // Inject a synthetic deploy node for hardware targets
-        const spec = event as any;
         const lastTaskId = planTasks.length > 0 ? planTasks[planTasks.length - 1].id : undefined;
-        const deployTarget = (spec.deployment_target as string) ?? '';
+        const deployTarget = event.deployment_target ?? '';
         if (deployTarget === 'esp32' || deployTarget === 'both') {
           planTasks.push({
             id: '__deploy__',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -80,7 +80,7 @@ export interface NarratorMessage {
 export type WSEvent =
   | { type: 'session_started'; session_id: string }
   | { type: 'planning_started' }
-  | { type: 'plan_ready'; tasks: Task[]; agents: Agent[]; explanation: string }
+  | { type: 'plan_ready'; tasks: Task[]; agents: Agent[]; explanation: string; deployment_target?: string }
   | { type: 'task_started'; task_id: string; agent_name: string }
   | { type: 'task_completed'; task_id: string; summary: string }
   | { type: 'task_failed'; task_id: string; error: string; retry_count: number }


### PR DESCRIPTION
## Summary

- Fix 7 distinct test/lint failures across 9 files that were causing CI to fail on all jobs
- Mock `node:child_process` in behavioral tests to prevent zombie `npx serve` processes and browser tabs opening during local test runs
- Add missing `deployment_target` field to `plan_ready` WSEvent type, removing `as any` lint violation

## Changes

| File | Fix |
|------|-----|
| `agentRunner.test.ts` | permissionMode expectation: `default` -> `bypassPermissions` |
| `helpers.ts` | try/catch around `rmSync` for Windows EPERM |
| `routes.behavior.test.ts` | `POST` -> `GET` for `/api/hardware/detect` |
| `executePhase.behavior.test.ts` | esp32 deploy tasks are skipped (handled by DeployPhase); added web target test |
| `orchestrator.behavior.test.ts` | Windows EPERM tolerance in cleanup test + mock `node:child_process` |
| `deployPhase.web.test.ts` | Mock `node:child_process` to prevent zombie servers and browser tabs |
| `BottomBar.test.tsx` | Board tab always renders; added missing `boardInfo` prop |
| `frontend/src/types/index.ts` | Added `deployment_target?: string` to `plan_ready` WSEvent |
| `useBuildSession.ts` | Removed `as any` cast, uses typed `event.deployment_target` |

## Test plan

- [x] Backend: 33 test files, 636 tests passing
- [x] Frontend: 33 test files, 370 tests passing
- [x] ESLint clean on `useBuildSession.ts`
- [x] No zombie `npx serve` processes after test runs
- [x] No browser tabs opened during test runs

Closes #53