### PR TITLE
Fix abort leaks, content safety, hardware races, magic numbers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,8 +114,10 @@ idle -> planning -> executing -> testing -> reviewing -> deploying -> done
 - **Agent isolation**: Each agent task runs as a separate SDK `query()` call. No shared state between agents except via context summaries written to `.elisa/` in the workspace.
 - **Context chain**: After each task, a summary is written to `.elisa/context/nugget_context.md`. Subsequent agents receive this as input, creating a chain of context.
 - **Graceful degradation**: Missing tools (git, pytest, mpremote, serialport) cause warnings, not crashes.
-- **No auth**: Local-only tool. CORS enabled only in dev mode (frontend on separate origin). In production (Electron), same-origin -- no CORS needed.
-- **API key management**: In dev, read from `ANTHROPIC_API_KEY` env var. In Electron, encrypted via OS keychain (`safeStorage`) and stored locally.
+- **Bearer token auth**: Server generates a random auth token on startup. All `/api/*` routes (except `/api/health`) require `Authorization: Bearer <token>`. WebSocket upgrades require `?token=<token>` query param. In Electron, token is shared to renderer via IPC.
+- **Content safety**: All agent prompts include a Content Safety section enforcing age-appropriate output (ages 8-14). User-controlled placeholder values are sanitized before prompt interpolation.
+- **Abort propagation**: Orchestrator's AbortController signal is forwarded to each agent's SDK `query()` call. On cancel or error, agents are aborted immediately.
+- **API key management**: In dev, read from `ANTHROPIC_API_KEY` env var. In Electron, encrypted via OS keychain (`safeStorage`) and stored locally. Child processes (test runners, flash scripts, builds) receive sanitized env without the API key.
 
 ## Storage
 

--- a/backend/src/prompts/builderAgent.test.ts
+++ b/backend/src/prompts/builderAgent.test.ts
@@ -22,6 +22,11 @@ describe('builderAgent SYSTEM_PROMPT', () => {
     expect(SYSTEM_PROMPT).toContain('multi-agent team');
   });
 
+  it('contains Content Safety section', () => {
+    expect(SYSTEM_PROMPT).toContain('Content Safety');
+    expect(SYSTEM_PROMPT).toContain('appropriate for children ages 8-14');
+  });
+
   it('contains security restrictions', () => {
     expect(SYSTEM_PROMPT).toContain('Security Restrictions');
     expect(SYSTEM_PROMPT).toContain('kid_skill');

--- a/backend/src/prompts/builderAgent.ts
+++ b/backend/src/prompts/builderAgent.ts
@@ -11,6 +11,9 @@ You are {agent_name}, a builder agent working on a kid's nugget in Elisa.
 ## Your Persona
 {persona}
 
+## Content Safety
+All generated content (code, comments, text, file names) must be appropriate for children ages 8-14. Do not generate violent, sexual, hateful, or otherwise inappropriate content. If the nugget goal contains inappropriate themes, interpret the goal in a wholesome, kid-friendly way.
+
 ## Team Briefing
 You are part of a multi-agent team building this nugget together. Previous agents may have \
 created files and written summaries of their work. Build on what they did -- do not start over. \

--- a/backend/src/prompts/metaPlanner.test.ts
+++ b/backend/src/prompts/metaPlanner.test.ts
@@ -6,6 +6,14 @@ import {
 } from './metaPlanner.js';
 
 describe('buildMetaPlannerSystem', () => {
+  it('contains Content Safety section', () => {
+    const result = buildMetaPlannerSystem({
+      nugget: { goal: 'A game', type: 'software' },
+    });
+    expect(result).toContain('Content Safety');
+    expect(result).toContain('appropriate for children ages 8-14');
+  });
+
   it('always includes base prompt sections', () => {
     const result = buildMetaPlannerSystem({
       nugget: { goal: 'A game', type: 'software' },
@@ -175,17 +183,18 @@ describe('META_PLANNER_SYSTEM (deprecated constant)', () => {
 });
 
 describe('metaPlannerUser', () => {
-  it('wraps spec JSON into a user prompt', () => {
+  it('wraps spec JSON into a user prompt with nugget_spec tags', () => {
     const spec = JSON.stringify({ nugget: { goal: 'A game' } });
     const result = metaPlannerUser(spec);
     expect(result).toContain("kid's nugget specification");
-    expect(result).toContain('NuggetSpec:');
+    expect(result).toContain('<nugget_spec>');
+    expect(result).toContain('</nugget_spec>');
     expect(result).toContain(spec);
   });
 
-  it('preserves exact JSON content', () => {
+  it('preserves exact JSON content inside nugget_spec tags', () => {
     const spec = '{"nugget":{"goal":"Test","type":"software"},"portals":[]}';
     const result = metaPlannerUser(spec);
-    expect(result).toContain(spec);
+    expect(result).toContain(`<nugget_spec>\n${spec}\n</nugget_spec>`);
   });
 });

--- a/backend/src/prompts/metaPlanner.ts
+++ b/backend/src/prompts/metaPlanner.ts
@@ -5,6 +5,9 @@ You are the Meta-Planner for Elisa, a kid-friendly IDE that orchestrates AI agen
 to build real software nuggets. A child has described their nugget using visual blocks, \
 and you must decompose it into a concrete task DAG (directed acyclic graph) that your minion squad can execute.
 
+## Content Safety
+All generated content (code, comments, text, file names) must be appropriate for children ages 8-14. Do not generate violent, sexual, hateful, or otherwise inappropriate content. If the nugget goal contains inappropriate themes, interpret the goal in a wholesome, kid-friendly way.
+
 ## Your Job
 
 1. Read the NuggetSpec JSON (goal, features, style preferences, agents, deployment target).
@@ -208,6 +211,6 @@ export const META_PLANNER_SYSTEM = META_PLANNER_BASE + HARDWARE_SECTION + PORTAL
 export function metaPlannerUser(specJson: string): string {
   return (
     "Here is the kid's nugget specification. Decompose it into a task DAG.\n\n" +
-    `NuggetSpec:\n${specJson}`
+    `<nugget_spec>\n${specJson}\n</nugget_spec>`
   );
 }

--- a/backend/src/prompts/reviewerAgent.test.ts
+++ b/backend/src/prompts/reviewerAgent.test.ts
@@ -36,6 +36,11 @@ describe('reviewerAgent SYSTEM_PROMPT', () => {
     expect(SYSTEM_PROMPT).toContain('NEEDS_CHANGES');
   });
 
+  it('contains Content Safety section', () => {
+    expect(SYSTEM_PROMPT).toContain('Content Safety');
+    expect(SYSTEM_PROMPT).toContain('appropriate for children ages 8-14');
+  });
+
   it('contains security restrictions', () => {
     expect(SYSTEM_PROMPT).toContain('Security Restrictions');
     expect(SYSTEM_PROMPT).toContain('kid_skill');

--- a/backend/src/prompts/reviewerAgent.ts
+++ b/backend/src/prompts/reviewerAgent.ts
@@ -13,6 +13,9 @@ You are {agent_name}, a code reviewer agent working on a kid's nugget in Elisa.
 ## Your Persona
 {persona}
 
+## Content Safety
+All generated content (code, comments, text, file names) must be appropriate for children ages 8-14. Do not generate violent, sexual, hateful, or otherwise inappropriate content. If the nugget goal contains inappropriate themes, interpret the goal in a wholesome, kid-friendly way.
+
 ## Team Briefing
 You are part of a multi-agent team building this nugget together. Builder and tester agents \
 have done their work. Review everything they built, check quality, and write a clear verdict \

--- a/backend/src/prompts/testerAgent.test.ts
+++ b/backend/src/prompts/testerAgent.test.ts
@@ -26,6 +26,11 @@ describe('testerAgent SYSTEM_PROMPT', () => {
     expect(SYSTEM_PROMPT).toContain('TESTER');
   });
 
+  it('contains Content Safety section', () => {
+    expect(SYSTEM_PROMPT).toContain('Content Safety');
+    expect(SYSTEM_PROMPT).toContain('appropriate for children ages 8-14');
+  });
+
   it('contains security restrictions', () => {
     expect(SYSTEM_PROMPT).toContain('Security Restrictions');
   });

--- a/backend/src/prompts/testerAgent.ts
+++ b/backend/src/prompts/testerAgent.ts
@@ -11,6 +11,9 @@ You are {agent_name}, a tester agent working on a kid's nugget in Elisa.
 ## Your Persona
 {persona}
 
+## Content Safety
+All generated content (code, comments, text, file names) must be appropriate for children ages 8-14. Do not generate violent, sexual, hateful, or otherwise inappropriate content. If the nugget goal contains inappropriate themes, interpret the goal in a wholesome, kid-friendly way.
+
 ## Team Briefing
 You are part of a multi-agent team building this nugget together. Builder agents have written \
 the code. Your job is to test their work thoroughly. Read their summaries, understand what was \

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -86,9 +86,22 @@ class ConnectionManager {
       }
     }
   }
+
+  cleanup(sessionId: string): void {
+    const conns = this.connections.get(sessionId);
+    if (conns) {
+      for (const ws of conns) {
+        try { ws.close(); } catch { /* ignore */ }
+      }
+      this.connections.delete(sessionId);
+    }
+  }
 }
 
 const manager = new ConnectionManager();
+
+// Wire up WebSocket cleanup when sessions are removed
+store.onCleanup = (sessionId: string) => manager.cleanup(sessionId);
 
 // -- Express App --
 

--- a/backend/src/services/CLAUDE.md
+++ b/backend/src/services/CLAUDE.md
@@ -24,7 +24,7 @@ Calls Claude API (opus model) with NuggetSpec + system prompt. Returns structure
 Wraps simple-git. Inits repo per session workspace, commits after each task with agent attribution. Tracks files changed per commit. Silently no-ops if git unavailable.
 
 ### hardwareService.ts (ESP32 integration)
-Board detection via USB VID:PID matching. Compiles MicroPython with py_compile. Flashes via mpremote. Serial monitor via serialport at 115200 baud. 60s flash timeout.
+Board detection via USB VID:PID matching. Compiles MicroPython with py_compile. Flashes via mpremote with Promise-chain mutex for concurrent flash protection. Serial monitor via serialport at 115200 baud. 60s flash timeout. Uses crypto.randomUUID() for temp file names. `probeForRepl` promisifies `sp.close()`.
 
 ### testRunner.ts (test execution)
 Detects project type from file extensions in `tests/`. Runs `pytest` for `.py` files, `node` for `.js`/`.mjs` files, merges results if both exist. Parses PASS/FAIL and TAP output formats for JS; pytest verbose output for Python. Extracts coverage for Python only. 120s timeout per runner.

--- a/backend/src/services/__tests__/hardwareService.test.ts
+++ b/backend/src/services/__tests__/hardwareService.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HardwareService } from '../hardwareService.js';
+
+// Mock child_process, fs, crypto so we never touch real hardware
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+vi.mock('node:crypto', () => ({
+  randomUUID: vi.fn(() => '00000000-1111-2222-3333-444444444444'),
+}));
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => 'print("hello")'),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    readdirSync: vi.fn(() => ['main.py']),
+    statSync: vi.fn(() => ({ isDirectory: () => false })),
+  },
+}));
+
+// Build a mock SerialPort that captures event listeners and can emit events
+function createMockSerialPort(opts?: { openError?: Error; replyData?: string; closeError?: Error }) {
+  const listeners: Record<string, ((...args: any[]) => void)[]> = {};
+
+  const mockClose = vi.fn((cb: (err?: Error | null) => void) => {
+    cb(opts?.closeError ?? null);
+  });
+
+  const instance = {
+    on: vi.fn((event: string, cb: (...args: any[]) => void) => {
+      listeners[event] = listeners[event] || [];
+      listeners[event].push(cb);
+
+      // Auto-fire 'open' or 'error' after registration
+      if (event === 'open' && !opts?.openError) {
+        setTimeout(() => cb(), 5);
+      }
+      if (event === 'error' && opts?.openError) {
+        setTimeout(() => cb(opts.openError), 5);
+      }
+      // Auto-fire 'data' after registration (with REPL prompt)
+      if (event === 'data' && opts?.replyData) {
+        setTimeout(() => cb(Buffer.from(opts.replyData!)), 20);
+      }
+    }),
+    write: vi.fn(),
+    close: mockClose,
+    pipe: vi.fn(),
+  };
+
+  return { instance, mockClose, listeners };
+}
+
+// We need to dynamically control what MockSerialPort returns per test
+let currentMockPort: ReturnType<typeof createMockSerialPort> | null = null;
+
+const MockSerialPortConstructor = vi.fn(function (this: any) {
+  if (currentMockPort) {
+    Object.assign(this, currentMockPort.instance);
+  }
+  return this;
+});
+(MockSerialPortConstructor as any).list = vi.fn(async () => []);
+
+vi.mock('serialport', () => ({
+  SerialPort: MockSerialPortConstructor,
+}));
+
+vi.mock('@serialport/parser-readline', () => ({
+  ReadlineParser: vi.fn(),
+}));
+
+describe('HardwareService', () => {
+  let service: HardwareService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentMockPort = null;
+    service = new HardwareService();
+  });
+
+  describe('flash mutex', () => {
+    it('serializes concurrent flash calls', async () => {
+      const executionOrder: number[] = [];
+
+      // Mock _flashImpl to track execution order
+      let call1Resolve: () => void;
+      const call1Gate = new Promise<void>(r => { call1Resolve = r; });
+
+      vi.spyOn(service as any, '_flashImpl')
+        .mockImplementationOnce(async () => {
+          executionOrder.push(1);
+          await call1Gate;
+          executionOrder.push(2);
+          return { success: true, message: 'first' };
+        })
+        .mockImplementationOnce(async () => {
+          executionOrder.push(3);
+          return { success: true, message: 'second' };
+        });
+
+      // Fire both flash calls concurrently
+      const p1 = service.flash('/work1');
+      const p2 = service.flash('/work2');
+
+      // Give the event loop time to start both
+      await new Promise(r => setTimeout(r, 50));
+
+      // Call 1 should be running, call 2 should be waiting on the mutex
+      expect(executionOrder).toEqual([1]);
+
+      // Release call 1
+      call1Resolve!();
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1.message).toBe('first');
+      expect(r2.message).toBe('second');
+
+      // Verify sequential: 1 started, 1 finished, then 2 started
+      expect(executionOrder).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('temp file names use UUID', () => {
+    it('generates temp file paths with UUID instead of Date.now()', async () => {
+      const fs = (await import('node:fs')).default;
+
+      // Mock detectBoard to return a port
+      vi.spyOn(service, 'detectBoard' as any).mockResolvedValue({
+        port: 'COM3',
+        boardType: 'ESP32',
+      });
+
+      // Mock execFile to simulate a failed flash
+      const { execFile } = await import('node:child_process');
+      (execFile as any).mockImplementation(
+        (_cmd: string, _args: string[], _opts: any, cb: any) => {
+          cb(new Error('mock fail'), '', 'mock error');
+        },
+      );
+
+      await service.flash('/work', 'COM3');
+
+      // Check writeFileSync was called with UUID-based filenames
+      const writeFileCalls = (fs.writeFileSync as any).mock.calls;
+      const manifestCall = writeFileCalls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('.json'),
+      );
+
+      expect(manifestCall).toBeDefined();
+      expect(manifestCall[0]).toContain('elisa-flash-');
+      expect(manifestCall[0]).toContain('00000000-1111-2222-3333-444444444444');
+      // Should NOT contain the old Date.now() pattern
+      expect(manifestCall[0]).not.toMatch(/elisa_flash_\d+/);
+      expect(manifestCall[0]).not.toMatch(/elisa_manifest_\d+/);
+    });
+  });
+
+  describe('probeForRepl', () => {
+    it('awaits port close and returns true when REPL found', async () => {
+      const mock = createMockSerialPort({ replyData: '>>>' });
+      currentMockPort = mock;
+
+      const result = await (service as any).probeForRepl('COM3');
+
+      expect(result).toBe(true);
+      // close should have been called via the awaited promisified pattern
+      expect(mock.mockClose).toHaveBeenCalledTimes(1);
+      expect(mock.mockClose).toHaveBeenCalledWith(expect.any(Function));
+    }, 10_000);
+
+    it('awaits port close and returns false on open error', async () => {
+      const mock = createMockSerialPort({ openError: new Error('open failed') });
+      currentMockPort = mock;
+
+      const result = await (service as any).probeForRepl('COM3');
+
+      expect(result).toBe(false);
+      // close should still be called in the catch block
+      expect(mock.mockClose).toHaveBeenCalled();
+    }, 10_000);
+
+    it('handles close error gracefully without throwing', async () => {
+      const mock = createMockSerialPort({
+        replyData: '>>>',
+        closeError: new Error('close failed'),
+      });
+      currentMockPort = mock;
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await (service as any).probeForRepl('COM3');
+
+      // Should resolve (not throw) even when close errors
+      expect(typeof result).toBe('boolean');
+      expect(warnSpy).toHaveBeenCalledWith('Port close warning:', 'close failed');
+      warnSpy.mockRestore();
+    }, 10_000);
+  });
+});

--- a/backend/src/services/agentRunner.ts
+++ b/backend/src/services/agentRunner.ts
@@ -24,6 +24,7 @@ export interface AgentRunnerParams {
   maxTurns?: number;
   mcpServers?: Array<{ name: string; command: string; args?: string[]; env?: Record<string, string> }>;
   allowedTools?: string[];
+  abortSignal?: AbortSignal;
 }
 
 export class AgentRunner {
@@ -50,6 +51,14 @@ export class AgentRunner {
       : undefined;
 
     const abortController = new AbortController();
+
+    if (params.abortSignal) {
+      if (params.abortSignal.aborted) {
+        abortController.abort();
+      } else {
+        params.abortSignal.addEventListener('abort', () => abortController.abort(), { once: true });
+      }
+    }
 
     try {
       return await withTimeout(

--- a/backend/src/services/metaPlanner.ts
+++ b/backend/src/services/metaPlanner.ts
@@ -2,6 +2,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { buildMetaPlannerSystem, META_PLANNER_SYSTEM, metaPlannerUser } from '../prompts/metaPlanner.js';
+import { DEFAULT_MODEL } from '../utils/constants.js';
 
 const DEFAULT_AGENTS = [
   {
@@ -37,7 +38,7 @@ export class MetaPlanner {
     const userMsg = metaPlannerUser(specJson);
     const systemPrompt = buildMetaPlannerSystem(spec);
 
-    const model = process.env.CLAUDE_MODEL || 'claude-opus-4-6';
+    const model = process.env.CLAUDE_MODEL || DEFAULT_MODEL;
     const response = await this.client.messages.create({
       model,
       system: systemPrompt,
@@ -64,7 +65,7 @@ export class MetaPlanner {
     originalUserMsg: string,
     badResponse: string,
   ): Promise<Record<string, any>> {
-    const model = process.env.CLAUDE_MODEL || 'claude-opus-4-6';
+    const model = process.env.CLAUDE_MODEL || DEFAULT_MODEL;
     const response = await this.client.messages.create({
       model,
       system: systemPrompt,

--- a/backend/src/services/narratorService.ts
+++ b/backend/src/services/narratorService.ts
@@ -2,6 +2,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { NARRATOR_SYSTEM_PROMPT, narratorUserPrompt } from '../prompts/narratorAgent.js';
+import { NARRATOR_TIMEOUT_MS, RATE_LIMIT_DELAY_MS } from '../utils/constants.js';
 
 export interface NarratorMessage {
   text: string;
@@ -97,7 +98,7 @@ export class NarratorService {
       }
 
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 4000);
+      const timeout = setTimeout(() => controller.abort(), NARRATOR_TIMEOUT_MS);
 
       const response = await this.client.messages.create(
         {
@@ -160,7 +161,7 @@ export class NarratorService {
 
       // Rate limit: skip if <15s since last emission for this task
       const lastTime = this.lastMessageTimes.get(taskId) ?? 0;
-      if (Date.now() - lastTime < 15000) return;
+      if (Date.now() - lastTime < RATE_LIMIT_DELAY_MS) return;
 
       const batchText = accumulated.join('\n').slice(0, 1000);
       const msg = await this.translate('agent_output', agentName, batchText, nuggetGoal);

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -161,6 +161,7 @@ export class Orchestrator {
         message: String(err.message || err),
         stack: err.stack,
       });
+      this.session.state = 'done';
       await this.send({
         type: 'error',
         message: String(err.message || err),
@@ -168,6 +169,7 @@ export class Orchestrator {
       });
     } finally {
       await this.deployPhase.teardown();
+      this.logger?.close();
     }
   }
 
@@ -212,7 +214,6 @@ export class Orchestrator {
   /** Signal cancellation to the execution loop and release resources. */
   cancel(): void {
     this.abortController.abort();
-    this.cleanup();
   }
 
   /** Clean up the nugget temp directory immediately (skipped for user workspaces). */

--- a/backend/src/services/testRunner.ts
+++ b/backend/src/services/testRunner.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { safeEnv } from '../utils/safeEnv.js';
 import { withTimeout } from '../utils/withTimeout.js';
+import { TEST_TIMEOUT_MS } from '../utils/constants.js';
 
 /** Detect which test file types exist in a directory. */
 function detectTestTypes(testsDir: string): { hasPython: boolean; hasJs: boolean } {
@@ -105,7 +106,7 @@ export class TestRunner {
         });
         const result = await withTimeout(
           execPromise,
-          120_000,
+          TEST_TIMEOUT_MS,
           { childProcess: childProc },
         );
         stdout = result.stdout ?? '';

--- a/backend/src/tests/behavioral/abort-leaks.behavior.test.ts
+++ b/backend/src/tests/behavioral/abort-leaks.behavior.test.ts
@@ -1,0 +1,295 @@
+/** Behavioral tests for #75 (abort signal propagation) and #76 (resource leaks). */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// -- Mock SDK before importing agentRunner --
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { AgentRunner } from '../../services/agentRunner.js';
+import { SessionLogger } from '../../utils/sessionLogger.js';
+import { ContextManager } from '../../utils/contextManager.js';
+import { SessionStore } from '../../services/sessionStore.js';
+
+const mockQuery = vi.mocked(query);
+
+async function* asyncIterable<T>(...items: T[]): AsyncGenerator<T, void> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+function makeResultMessage(overrides: Record<string, any> = {}) {
+  return {
+    type: 'result',
+    subtype: 'success',
+    result: 'Done',
+    total_cost_usd: 0.05,
+    usage: { input_tokens: 100, output_tokens: 50 },
+    ...overrides,
+  };
+}
+
+// ============================================================
+// #75: AbortSignal propagation to Agent SDK
+// ============================================================
+
+describe('AbortSignal propagation (#75)', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('links external abortSignal to internal AbortController', async () => {
+    let capturedAbortController: AbortController | undefined;
+    mockQuery.mockImplementation((opts: any) => {
+      capturedAbortController = opts.options?.abortController;
+      return asyncIterable(makeResultMessage()) as any;
+    });
+
+    const externalController = new AbortController();
+    const runner = new AgentRunner();
+    await runner.execute({
+      taskId: 'test-1',
+      prompt: 'hello',
+      systemPrompt: 'system',
+      onOutput: vi.fn().mockResolvedValue(undefined),
+      workingDir: '/tmp/test',
+      abortSignal: externalController.signal,
+    });
+
+    expect(capturedAbortController).toBeDefined();
+    expect(capturedAbortController!.signal.aborted).toBe(false);
+
+    // Abort the external signal -> internal controller should follow
+    externalController.abort();
+    expect(capturedAbortController!.signal.aborted).toBe(true);
+  });
+
+  it('does not abort internal controller when no external signal provided', async () => {
+    let capturedAbortController: AbortController | undefined;
+    mockQuery.mockImplementation((opts: any) => {
+      capturedAbortController = opts.options?.abortController;
+      return asyncIterable(makeResultMessage()) as any;
+    });
+
+    const runner = new AgentRunner();
+    await runner.execute({
+      taskId: 'test-1',
+      prompt: 'hello',
+      systemPrompt: 'system',
+      onOutput: vi.fn().mockResolvedValue(undefined),
+      workingDir: '/tmp/test',
+    });
+
+    expect(capturedAbortController).toBeDefined();
+    expect(capturedAbortController!.signal.aborted).toBe(false);
+  });
+
+  it('already-aborted external signal immediately aborts internal controller', async () => {
+    let capturedAbortController: AbortController | undefined;
+    mockQuery.mockImplementation((opts: any) => {
+      capturedAbortController = opts.options?.abortController;
+      return asyncIterable(makeResultMessage()) as any;
+    });
+
+    const externalController = new AbortController();
+    externalController.abort(); // Already aborted
+
+    const runner = new AgentRunner();
+    await runner.execute({
+      taskId: 'test-1',
+      prompt: 'hello',
+      systemPrompt: 'system',
+      onOutput: vi.fn().mockResolvedValue(undefined),
+      workingDir: '/tmp/test',
+      abortSignal: externalController.signal,
+    });
+
+    expect(capturedAbortController!.signal.aborted).toBe(true);
+  });
+});
+
+// ============================================================
+// #76: SessionLogger close() releases streams
+// ============================================================
+
+describe('SessionLogger close() releases streams (#76)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'elisa-logger-leak-test-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('close() ends both write streams and flushes content', async () => {
+    const logger = new SessionLogger(tmpDir);
+    logger.info('test entry');
+    logger.close();
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const jsonlPath = path.join(tmpDir, '.elisa', 'logs', 'session.jsonl');
+    const logPath = path.join(tmpDir, '.elisa', 'logs', 'session.log');
+    expect(fs.existsSync(jsonlPath)).toBe(true);
+    expect(fs.existsSync(logPath)).toBe(true);
+
+    const jsonlContent = fs.readFileSync(jsonlPath, 'utf-8');
+    expect(jsonlContent).toContain('test entry');
+  });
+
+  it('close() is idempotent (no throw on double close)', () => {
+    const logger = new SessionLogger(tmpDir);
+    logger.info('entry');
+    expect(() => {
+      logger.close();
+      logger.close();
+    }).not.toThrow();
+  });
+});
+
+// ============================================================
+// #76: contextManager buildFileManifest FD leak prevention
+// ============================================================
+
+describe('contextManager buildFileManifest FD safety (#76)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'elisa-ctx-fd-test-'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('closes FD in finally block when readSync throws', () => {
+    const testFile = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(testFile, 'hello world');
+
+    // Track closeSync calls with the real fd from openSync
+    const originalOpenSync = fs.openSync;
+    const originalCloseSync = fs.closeSync;
+    let openedFd: number | undefined;
+    let closedFds: number[] = [];
+
+    vi.spyOn(fs, 'openSync').mockImplementation((...args: any[]) => {
+      const fd = originalOpenSync.apply(fs, args as any);
+      openedFd = fd;
+      return fd;
+    });
+
+    vi.spyOn(fs, 'readSync').mockImplementation(() => {
+      throw new Error('Simulated read error');
+    });
+
+    vi.spyOn(fs, 'closeSync').mockImplementation((fd: number) => {
+      closedFds.push(fd);
+      return originalCloseSync(fd);
+    });
+
+    const manifest = ContextManager.buildFileManifest(tmpDir);
+    expect(manifest).toBeDefined();
+    // The FD that was opened should have been closed in the finally block
+    expect(openedFd).toBeDefined();
+    expect(closedFds).toContain(openedFd);
+  });
+
+  it('produces manifest with file hints when no errors occur', () => {
+    const testFile = path.join(tmpDir, 'hello.js');
+    fs.writeFileSync(testFile, '// JavaScript file\nconsole.log("hi");');
+
+    const manifest = ContextManager.buildFileManifest(tmpDir);
+    expect(manifest).toContain('hello.js');
+    // The hint is prefixed with "  # " in the manifest
+    expect(manifest).toContain('# // JavaScript file');
+  });
+});
+
+// ============================================================
+// #76: ConnectionManager cleanup via SessionStore onCleanup
+// ============================================================
+
+describe('ConnectionManager cleanup via SessionStore (#76)', () => {
+  it('onCleanup callback is invoked when scheduleCleanup fires', async () => {
+    const store = new SessionStore(false);
+    const cleanedIds: string[] = [];
+    store.onCleanup = (id: string) => cleanedIds.push(id);
+
+    store.create('session-1', {
+      id: 'session-1',
+      state: 'done',
+      tasks: [],
+      agents: [],
+    } as any);
+
+    store.scheduleCleanup('session-1', 50);
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(cleanedIds).toContain('session-1');
+    expect(store.has('session-1')).toBe(false);
+  });
+
+  it('onCleanup callback is invoked during pruneStale', async () => {
+    const store = new SessionStore(false);
+    const cleanedIds: string[] = [];
+    store.onCleanup = (id: string) => cleanedIds.push(id);
+
+    store.create('session-old', {
+      id: 'session-old',
+      state: 'done',
+      tasks: [],
+      agents: [],
+    } as any);
+
+    // Wait 2ms so that the session age > 1ms threshold
+    await new Promise((r) => setTimeout(r, 2));
+    store.pruneStale(1);
+
+    expect(cleanedIds).toContain('session-old');
+    expect(store.has('session-old')).toBe(false);
+  });
+});
+
+// ============================================================
+// #75/#76: Orchestrator sets state to 'done' on error
+// ============================================================
+
+describe('Orchestrator error handling (#75/#76)', () => {
+  it('sets session state to done when run() throws', async () => {
+    const { Orchestrator } = await import('../../services/orchestrator.js');
+
+    const session = {
+      id: 'test-session',
+      state: 'idle',
+      spec: null,
+      tasks: [],
+      agents: [],
+    } as any;
+
+    const sentEvents: Record<string, any>[] = [];
+    const sendEvent = async (evt: Record<string, any>) => { sentEvents.push(evt); };
+
+    const orchestrator = new Orchestrator(session, sendEvent);
+
+    // run() with an invalid spec should cause an error during planning
+    await orchestrator.run({ invalid: true });
+
+    expect(session.state).toBe('done');
+
+    const errorEvents = sentEvents.filter((e) => e.type === 'error');
+    expect(errorEvents.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/backend/src/utils/constants.test.ts
+++ b/backend/src/utils/constants.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_MODEL,
+  AGENT_TIMEOUT_SECONDS,
+  MAX_CONCURRENT_TASKS,
+  TEST_TIMEOUT_MS,
+  BUILD_TIMEOUT_MS,
+  FLASH_TIMEOUT_MS,
+  NARRATOR_TIMEOUT_MS,
+  RATE_LIMIT_DELAY_MS,
+  CLEANUP_DELAY_MS,
+  SESSION_MAX_AGE_MS,
+  PRUNE_INTERVAL_MS,
+  PREDECESSOR_WORD_CAP,
+  DEFAULT_TOKEN_BUDGET,
+} from './constants.js';
+
+describe('constants', () => {
+  it('DEFAULT_MODEL is a non-empty string', () => {
+    expect(typeof DEFAULT_MODEL).toBe('string');
+    expect(DEFAULT_MODEL.length).toBeGreaterThan(0);
+  });
+
+  it('all timeout constants are positive numbers', () => {
+    const timeouts = [
+      AGENT_TIMEOUT_SECONDS,
+      TEST_TIMEOUT_MS,
+      BUILD_TIMEOUT_MS,
+      FLASH_TIMEOUT_MS,
+      NARRATOR_TIMEOUT_MS,
+      RATE_LIMIT_DELAY_MS,
+      CLEANUP_DELAY_MS,
+      SESSION_MAX_AGE_MS,
+      PRUNE_INTERVAL_MS,
+    ];
+    for (const val of timeouts) {
+      expect(typeof val).toBe('number');
+      expect(val).toBeGreaterThan(0);
+    }
+  });
+
+  it('MAX_CONCURRENT_TASKS is at least 1', () => {
+    expect(MAX_CONCURRENT_TASKS).toBeGreaterThanOrEqual(1);
+  });
+
+  it('PREDECESSOR_WORD_CAP is a positive number', () => {
+    expect(PREDECESSOR_WORD_CAP).toBeGreaterThan(0);
+  });
+
+  it('DEFAULT_TOKEN_BUDGET matches tokenTracker export', () => {
+    expect(DEFAULT_TOKEN_BUDGET).toBe(500_000);
+  });
+});

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,0 +1,40 @@
+/** Shared constants for magic numbers used across the backend. */
+
+/** Default Claude model used by agents and meta-planner. */
+export const DEFAULT_MODEL = 'claude-opus-4-6';
+
+/** Agent execution timeout in seconds. */
+export const AGENT_TIMEOUT_SECONDS = 300;
+
+/** Maximum concurrent agent tasks. */
+export const MAX_CONCURRENT_TASKS = 3;
+
+/** Test runner timeout in milliseconds. */
+export const TEST_TIMEOUT_MS = 120_000;
+
+/** Build step timeout in milliseconds. */
+export const BUILD_TIMEOUT_MS = 120_000;
+
+/** Flash timeout in milliseconds. */
+export const FLASH_TIMEOUT_MS = 60_000;
+
+/** Narrator debounce timeout in milliseconds. */
+export const NARRATOR_TIMEOUT_MS = 4_000;
+
+/** Rate limit delay in milliseconds. */
+export const RATE_LIMIT_DELAY_MS = 15_000;
+
+/** Session cleanup grace period in milliseconds. */
+export const CLEANUP_DELAY_MS = 300_000;
+
+/** Session max age in milliseconds. */
+export const SESSION_MAX_AGE_MS = 3_600_000;
+
+/** Session prune interval in milliseconds. */
+export const PRUNE_INTERVAL_MS = 600_000;
+
+/** Maximum predecessor word count for context. */
+export const PREDECESSOR_WORD_CAP = 2000;
+
+/** Default token budget per session. */
+export const DEFAULT_TOKEN_BUDGET = 500_000;

--- a/backend/src/utils/contextManager.ts
+++ b/backend/src/utils/contextManager.ts
@@ -59,15 +59,17 @@ export class ContextManager {
           if (entries.length >= maxEntries) return;
           const rel = path.relative(workDir, full).replace(/\\/g, '/');
           let hint = '';
+          let fd: number | undefined;
           try {
-            const fd = fs.openSync(full, 'r');
+            fd = fs.openSync(full, 'r');
             const buf = Buffer.alloc(256);
             const bytesRead = fs.readSync(fd, buf, 0, 256, 0);
-            fs.closeSync(fd);
             const firstLine = buf.toString('utf-8', 0, bytesRead).split('\n')[0].trim();
             if (firstLine) hint = `  # ${firstLine.slice(0, 80)}`;
           } catch {
             // skip
+          } finally {
+            if (fd !== undefined) try { fs.closeSync(fd); } catch { /* ignore */ }
           }
           entries.push(`${rel}${hint}`);
         }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -106,6 +106,9 @@ Block-based visual programming IDE where kids build software by snapping togethe
 | `backend/src/utils/sessionPersistence.ts` | Atomic JSON checkpoint/recovery |
 | `backend/src/utils/tokenTracker.ts` | Token tracking, cost per agent, budget enforcement |
 | `backend/src/utils/withTimeout.ts` | Generic promise timeout wrapper with AbortSignal support |
+| `backend/src/utils/constants.ts` | Named constants for timeouts, limits, intervals, default model |
+| `backend/src/utils/pathValidator.ts` | Workspace path validation (blocklist for system/sensitive dirs) |
+| `backend/src/utils/safeEnv.ts` | Sanitized process.env copy (strips ANTHROPIC_API_KEY) |
 
 ### Prompts
 

--- a/docs/sprint-2-plan.md
+++ b/docs/sprint-2-plan.md
@@ -1,0 +1,47 @@
+# Sprint 2: Bugs + Safety
+
+## Scope
+
+Fix runtime bugs and safety gaps that affect users during builds.
+
+## Agents
+
+### agent-abort-leaks (#75, #76)
+- Propagate abort signal from orchestrator to Agent SDK
+- Set session state to `done` on orchestrator error
+- Don't call cleanup() from cancel() -- let scheduleCleanup handle it
+- Close SessionLogger in orchestrator finally block
+- Fix file descriptor leak in contextManager.ts buildFileManifest
+- Remove abort event listeners in finally/cleanup path
+- Clean up question resolvers on task timeout/abort
+- Add ConnectionManager.cleanup(sessionId) for WebSocket cleanup
+
+Files: orchestrator.ts, executePhase.ts, agentRunner.ts, sessionLogger.ts, contextManager.ts, server.ts
+
+### agent-content-filter (#71)
+- Add age-appropriate content filter to all 4 agent prompts
+- Add content filter to metaPlanner prompt
+- Sanitize placeholders (strip ##, <, >, triple backticks) before interpolation
+- Change "mandatory constraints" to "creative guidelines"
+- Wrap NuggetSpec in boundary tags in meta-planner
+
+Files: prompts/builderAgent.ts, prompts/testerAgent.ts, prompts/reviewerAgent.ts, prompts/metaPlanner.ts, executePhase.ts (placeholder sanitization only)
+
+### agent-hardware (#86)
+- Add mutex to HardwareService for concurrent flash protection
+- Promisify and await sp.close() in probeForRepl
+- Use crypto.randomUUID() for temp file names instead of Date.now()
+
+Files: hardwareService.ts, routes/hardware.ts
+
+### agent-magic-numbers (#82 subset)
+- Extract sendDeployChecklist(ctx) to DRY the 3x before_deploy pattern
+- Define DEFAULT_MODEL constant, replace hardcoded 'claude-opus-4-6'
+- Extract named constants for magic numbers (timeouts, limits, intervals)
+
+Files: deployPhase.ts, metaPlanner.ts, executePhase.ts, various
+
+## Post-Sprint
+- All changes must include tests
+- Update CLAUDE.md docs and ARCHITECTURE.md if topology changes
+- All backend + frontend tests must pass


### PR DESCRIPTION
## Summary

Sprint 2: Bugs + Safety -- fixes runtime bugs and safety gaps across 4 issue areas.

**Abort signal propagation + resource leaks (#75, #76)**
- Propagate orchestrator abort signal to Agent SDK `query()` calls
- Set session state to `done` on orchestrator error
- Close SessionLogger in orchestrator `finally` block
- Fix file descriptor leak in `contextManager.ts` `buildFileManifest`
- Add `ConnectionManager.cleanup(sessionId)` for WebSocket teardown
- Clean up question resolvers on task completion/failure

**Content safety (#71)**
- Add age-appropriate content filter to all 4 agent prompts + meta-planner
- Sanitize user-controlled placeholders before prompt interpolation
- Wrap NuggetSpec in boundary tags in meta-planner user prompt
- Change "mandatory constraints" to "creative guidelines"

**Hardware race conditions (#86)**
- Add Promise-chain mutex to `HardwareService.flash()` for concurrent flash protection
- Promisify and await `sp.close()` in `probeForRepl`
- Use `crypto.randomUUID()` for temp file names instead of `Date.now()`

**Magic numbers / DRY (#82 subset)**
- Extract `DEFAULT_MODEL` constant, replace all hardcoded model strings
- Extract named constants for timeouts, limits, intervals to `constants.ts`
- Extract `sendDeployChecklist(ctx)` to DRY the 3x `before_deploy` pattern

Closes #75, closes #76, closes #71, closes #86

## Test plan

- [x] All 861 backend tests pass (29 new tests added)
- [x] All 495 frontend tests pass
- [x] New behavioral tests for abort signal propagation, session cleanup, FD safety
- [x] New hardware service tests for flash mutex, UUID temp files, probeForRepl
- [x] New tests for sanitizePlaceholder, constants module, content safety in prompts
- [x] Documentation updated: ARCHITECTURE.md, backend CLAUDE.md, services CLAUDE.md, docs/INDEX.md

Generated with [Claude Code](https://claude.com/claude-code)