### PR TITLE
Sprint 4: Skills & Rules system polish

### DIFF
--- a/backend/src/prompts/teaching.ts
+++ b/backend/src/prompts/teaching.ts
@@ -188,6 +188,29 @@ export const CONCEPT_CURRICULUM: Record<string, Record<string, TeachingMomentDat
         "In real software teams, these are called 'linting rules' or 'code standards'. " +
         'They catch mistakes automatically so the team can focus on building cool stuff.',
     },
+    composite_skill: {
+      concept: 'prompt_engineering',
+      headline: 'You built a multi-step skill -- nice work!',
+      explanation:
+        'A composite skill chains multiple steps together: ask questions, branch on answers, ' +
+        'and run different agents. It is like writing a recipe with decision points -- ' +
+        '"if the user wants chocolate, do this; if vanilla, do that."',
+      tell_me_more:
+        'Composite skills can even call other skills inside them, like nesting functions ' +
+        'in a program. This lets you build complex workflows from simple, reusable pieces.',
+    },
+    context_variables: {
+      concept: 'prompt_engineering',
+      headline: 'Context variables connect your skill steps!',
+      explanation:
+        'When you use {{key}} in a prompt, the skill engine replaces it with a value ' +
+        'from an earlier step. It is like filling in blanks on a form -- each step ' +
+        'can read what the previous steps wrote.',
+      tell_me_more:
+        'Context flows from parent skills to child skills too. If a skill calls another ' +
+        'skill, the inner skill can read the outer skill\'s values. This is similar to ' +
+        'how variables work in programming -- inner scopes can see outer scopes.',
+    },
   },
   code_review: {
     first_review: {

--- a/backend/src/services/teachingEngine.test.ts
+++ b/backend/src/services/teachingEngine.test.ts
@@ -135,4 +135,45 @@ describe('TeachingEngine', () => {
     expect(planning!.concept).toBe('decomposition');
     expect(testing!.concept).toBe('testing');
   });
+
+  it('composite_skill_created returns a teaching moment on first call', async () => {
+    const moment = await engine.getMoment('composite_skill_created');
+
+    expect(moment).not.toBeNull();
+    expect(moment!.concept).toBe('prompt_engineering');
+    expect(moment!.headline).toBeTruthy();
+    expect(moment!.explanation).toBeTruthy();
+    expect(moment!.tell_me_more).toBeTruthy();
+  });
+
+  it('composite_skill_created deduplicates on second call', async () => {
+    const first = await engine.getMoment('composite_skill_created');
+    expect(first).not.toBeNull();
+
+    const second = await engine.getMoment('composite_skill_created');
+    expect(second).toBeNull();
+  });
+
+  it('context_variable_used returns a teaching moment', async () => {
+    const moment = await engine.getMoment('context_variable_used');
+
+    expect(moment).not.toBeNull();
+    expect(moment!.concept).toBe('prompt_engineering');
+    expect(moment!.headline).toBeTruthy();
+    expect(moment!.explanation).toBeTruthy();
+    expect(moment!.tell_me_more).toBeTruthy();
+  });
+
+  it('composite_skill and context_variables curriculum content is non-empty', async () => {
+    const composite = await engine.getMoment('composite_skill_created');
+    const context = await engine.getMoment('context_variable_used');
+
+    expect(composite!.headline.length).toBeGreaterThan(0);
+    expect(composite!.explanation.length).toBeGreaterThan(0);
+    expect(composite!.tell_me_more.length).toBeGreaterThan(0);
+
+    expect(context!.headline.length).toBeGreaterThan(0);
+    expect(context!.explanation.length).toBeGreaterThan(0);
+    expect(context!.tell_me_more.length).toBeGreaterThan(0);
+  });
 });

--- a/backend/src/services/teachingEngine.ts
+++ b/backend/src/services/teachingEngine.ts
@@ -24,6 +24,8 @@ const TRIGGER_MAP: Record<string, [string, string]> = {
   hardware_lora: ['hardware', 'lora'],
   skill_used: ['prompt_engineering', 'first_skill'],
   rule_used: ['prompt_engineering', 'first_rule'],
+  composite_skill_created: ['prompt_engineering', 'composite_skill'],
+  context_variable_used: ['prompt_engineering', 'context_variables'],
 };
 
 export class TeachingEngine {

--- a/backend/src/tests/behavioral/skillsRoute.behavior.test.ts
+++ b/backend/src/tests/behavioral/skillsRoute.behavior.test.ts
@@ -1,0 +1,346 @@
+/** Behavioral tests for skill route handlers: /api/skills/*
+ *
+ * Starts a real HTTP server on port 0 and exercises each endpoint
+ * via fetch(). Mocks AgentRunner and SkillRunner to avoid Claude API calls.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import http from 'node:http';
+
+// Mock Orchestrator to avoid real Claude API calls
+vi.mock('../../services/orchestrator.js', () => {
+  const MockOrchestrator = vi.fn(function (this: any) {
+    this.run = vi.fn().mockResolvedValue(undefined);
+    this.cancel = vi.fn();
+    this.cleanup = vi.fn();
+    this.getCommits = vi.fn().mockReturnValue([]);
+    this.getTestResults = vi.fn().mockReturnValue({});
+    this.respondToGate = vi.fn();
+    this.respondToQuestion = vi.fn();
+    this.nuggetDir = '/tmp/test-nugget';
+  });
+  return { Orchestrator: MockOrchestrator };
+});
+
+// Mock AgentRunner to avoid real SDK calls
+vi.mock('../../services/agentRunner.js', () => {
+  const MockAgentRunner = vi.fn(function (this: any) {
+    this.execute = vi.fn().mockResolvedValue({
+      success: true, summary: 'done', costUsd: 0, inputTokens: 0, outputTokens: 0,
+    });
+  });
+  return { AgentRunner: MockAgentRunner };
+});
+
+// Mock SkillRunner to avoid real execution
+vi.mock('../../services/skillRunner.js', () => {
+  const MockSkillRunner = vi.fn(function (this: any) {
+    this.execute = vi.fn().mockResolvedValue('result');
+    this.respondToQuestion = vi.fn();
+    this.interpretWorkspaceOnBackend = vi.fn().mockReturnValue({});
+  });
+  return { SkillRunner: MockSkillRunner };
+});
+
+import { startServer } from '../../server.js';
+
+let server: http.Server | null = null;
+let authToken: string | null = null;
+
+function getPort(srv: http.Server): number {
+  const addr = srv.address();
+  return typeof addr === 'object' && addr ? addr.port : 0;
+}
+
+function baseUrl(): string {
+  return `http://127.0.0.1:${getPort(server!)}`;
+}
+
+function authHeaders(extra?: Record<string, string>): Record<string, string> {
+  return {
+    ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+    ...extra,
+  };
+}
+
+function jsonAuthHeaders(): Record<string, string> {
+  return authHeaders({ 'Content-Type': 'application/json' });
+}
+
+async function startTestServer(): Promise<void> {
+  const result = await startServer(0);
+  server = result.server;
+  authToken = result.authToken;
+}
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = null;
+  }
+  authToken = null;
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/skills/run
+// ---------------------------------------------------------------------------
+
+describe('POST /api/skills/run - valid plan', () => {
+  it('returns session_id when a valid plan is provided', async () => {
+    await startTestServer();
+    const plan = {
+      skillName: 'test-skill',
+      steps: [{ id: 'step-1', type: 'output', template: 'hello world' }],
+    };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('session_id');
+    expect(typeof body.session_id).toBe('string');
+    expect(body.session_id.length).toBeGreaterThan(0);
+  });
+
+  it('accepts plan with allSkills array', async () => {
+    await startTestServer();
+    const plan = {
+      skillName: 'parent-skill',
+      steps: [
+        { id: 'step-1', type: 'invoke_skill', skillId: 'child-1', storeAs: 'result' },
+      ],
+    };
+    const allSkills = [
+      { id: 'child-1', name: 'Child', prompt: 'Do something', category: 'agent' },
+    ];
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan, allSkills }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('session_id');
+  });
+});
+
+describe('POST /api/skills/run - invalid plan (missing fields)', () => {
+  it('returns 400 when plan is missing entirely', async () => {
+    await startTestServer();
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.detail).toBe('Invalid skill plan');
+    expect(body.errors).toBeDefined();
+    expect(Array.isArray(body.errors)).toBe(true);
+  });
+
+  it('returns 400 when plan has no skillName', async () => {
+    await startTestServer();
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan: { steps: [] } }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.detail).toBe('Invalid skill plan');
+  });
+
+  it('returns 400 when plan has no steps array', async () => {
+    await startTestServer();
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan: { skillName: 'test' } }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.detail).toBe('Invalid skill plan');
+  });
+
+  it('returns 400 when step has invalid type', async () => {
+    await startTestServer();
+    const plan = {
+      skillName: 'test',
+      steps: [{ id: 'step-1', type: 'nonexistent_type' }],
+    };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.detail).toBe('Invalid skill plan');
+  });
+
+  it('returns 400 when step is missing required fields for its type', async () => {
+    await startTestServer();
+    // run_agent requires prompt and storeAs
+    const plan = {
+      skillName: 'test',
+      steps: [{ id: 'step-1', type: 'run_agent' }],
+    };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.detail).toBe('Invalid skill plan');
+  });
+});
+
+describe('POST /api/skills/run - overly long strings', () => {
+  it('returns 400 when skillName exceeds 200 chars', async () => {
+    await startTestServer();
+    const plan = {
+      skillName: 'x'.repeat(201),
+      steps: [],
+    };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.detail).toBe('Invalid skill plan');
+  });
+
+  it('returns 400 when step id exceeds 200 chars', async () => {
+    await startTestServer();
+    const plan = {
+      skillName: 'test',
+      steps: [{ id: 'x'.repeat(201), type: 'output', template: 'hello' }],
+    };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when run_agent prompt exceeds 5000 chars', async () => {
+    await startTestServer();
+    const plan = {
+      skillName: 'test',
+      steps: [{
+        id: 'step-1',
+        type: 'run_agent',
+        prompt: 'p'.repeat(5001),
+        storeAs: 'result',
+      }],
+    };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when plan has more than 50 steps', async () => {
+    await startTestServer();
+    const steps = Array.from({ length: 51 }, (_, i) => ({
+      id: `step-${i}`,
+      type: 'output' as const,
+      template: 'hello',
+    }));
+    const plan = { skillName: 'test', steps };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when output template exceeds 5000 chars', async () => {
+    await startTestServer();
+    const plan = {
+      skillName: 'test',
+      steps: [{
+        id: 'step-1',
+        type: 'output',
+        template: 't'.repeat(5001),
+      }],
+    };
+    const res = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/skills/:id/answer
+// ---------------------------------------------------------------------------
+
+describe('POST /api/skills/:id/answer - invalid session', () => {
+  it('returns 404 when session does not exist', async () => {
+    await startTestServer();
+    const res = await fetch(`${baseUrl()}/api/skills/nonexistent-session-id/answer`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ step_id: 'step-1', answers: { Color: 'blue' } }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.detail).toBe('Skill session not found');
+  });
+
+  it('returns 404 when session exists but has no skill runner', async () => {
+    await startTestServer();
+    // Create a regular session (no skill runner attached)
+    const createRes = await fetch(`${baseUrl()}/api/sessions`, {
+      method: 'POST',
+      headers: authHeaders(),
+    });
+    const { session_id } = await createRes.json();
+
+    const res = await fetch(`${baseUrl()}/api/skills/${session_id}/answer`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ step_id: 'step-1', answers: {} }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.detail).toBe('Skill session not found');
+  });
+
+  it('returns ok when session has a skill runner', async () => {
+    await startTestServer();
+    // Create a skill session by running a valid plan
+    const plan = {
+      skillName: 'test-skill',
+      steps: [{ id: 'step-1', type: 'output', template: 'hello' }],
+    };
+    const runRes = await fetch(`${baseUrl()}/api/skills/run`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ plan }),
+    });
+    const { session_id } = await runRes.json();
+
+    const res = await fetch(`${baseUrl()}/api/skills/${session_id}/answer`, {
+      method: 'POST',
+      headers: jsonAuthHeaders(),
+      body: JSON.stringify({ step_id: 'step-1', answers: { Choice: 'A' } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+  });
+});

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,7 +24,8 @@ Block-based visual programming IDE where kids build software by snapping togethe
 | `frontend/src/components/TaskMap/` | DAG visualization (@xyflow/react) |
 | `frontend/src/components/MissionControl/` | Shared: TaskDAG, CommsFeed, MetricsPanel |
 | `frontend/src/components/BottomBar/` | Tabs: Timeline, Tests, Board, Learn, Progress, Tokens |
-| `frontend/src/components/Skills/` | Skills/rules CRUD modal |
+| `frontend/src/components/Skills/` | Skills CRUD modal + template library |
+| `frontend/src/components/Rules/` | Rules CRUD modal + template library |
 | `frontend/src/components/Portals/` | Portal connections modal |
 | `frontend/src/components/shared/` | Reusable: tabs, buttons, modals, toasts, avatars |
 | `frontend/src/hooks/` | React hooks (session state, health, WebSocket, board detect, skills) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,6 +39,18 @@ Open `http://localhost:5173` in your browser.
 4. **Interact** -- If you placed a "check with me" block, the build pauses with a modal asking for your approval. Agents may also ask questions mid-build.
 5. **Done** -- When the session completes, you have a working project with git history.
 
+## Skills and Rules
+
+After your first build, try extending your agents with custom Skills and Rules.
+
+**Create a Skill** -- Open the Skills modal from the sidebar (wrench icon). Give it a name, a prompt, and a category (`agent`, `feature`, or `style`). Drag a "Use Skill" block onto the canvas to include it in your next build.
+
+**Create a Rule** -- Open the Rules modal from the sidebar (shield icon). Rules are guardrails that trigger automatically (`always`, `on_task_complete`, `on_test_fail`, `before_deploy`). Drag an "Apply Rule" block onto the canvas.
+
+**Composite Skills** -- Open the flow editor inside the Skills modal to chain steps together: ask the user a question, branch on the answer, run agents, and invoke other skills. Use `{{key}}` syntax to reference context variables between steps.
+
+Skills and Rules have separate sidebar buttons for quick access.
+
 ## Troubleshooting
 
 **Backend won't start** -- Confirm `ANTHROPIC_API_KEY` is set in your environment. The server needs it for the meta-planner and teaching engine.

--- a/docs/hackathon-tasks.md
+++ b/docs/hackathon-tasks.md
@@ -103,7 +103,7 @@ Files and specific changes:
    - Backdrop div: add `role="dialog"` `aria-modal="true"` `aria-labelledby="question-modal-title"`
    - Heading element: add `id="question-modal-title"`
 
-3. `frontend/src/components/Skills/SkillsRulesModal.tsx`
+3. `frontend/src/components/Skills/SkillsModal.tsx`
    - Backdrop div: add `role="dialog"` `aria-modal="true"` `aria-labelledby="skills-modal-title"`
    - Heading: add `id="skills-modal-title"`
 
@@ -163,5 +163,5 @@ No new test files needed for a11y attributes. Existing tests should continue to 
 - `frontend/src/components/shared/GoButton.tsx`
 - `frontend/src/components/shared/TeachingToast.tsx`
 - `frontend/src/components/shared/ExamplePickerModal.tsx`
-- `frontend/src/components/Skills/SkillsRulesModal.tsx`
+- `frontend/src/components/Skills/SkillsModal.tsx`
 - `frontend/src/components/Portals/PortalsModal.tsx`

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -21,7 +21,8 @@ src/
     TaskMap/                 Full-width interactive task DAG panel (Tasks tab)
     MissionControl/          Shared subcomponents: TaskDAG, CommsFeed, MetricsPanel
     BottomBar/               Bottom tabs: timeline, tests, board, learn, progress, tokens
-    Skills/                  Skills & Rules editor modal + registry
+    Skills/                  Skills editor modal + template library
+    Rules/                   Rules editor modal + template library
     Portals/                 Portals editor modal + registry
     shared/                  MainTabBar, GoButton, HumanGateModal, QuestionModal, TeachingToast, AgentAvatar, ReadinessBadge, ExamplePickerModal, DirectoryPickerModal
   hooks/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -47,7 +47,9 @@ src/
       TeachingToast.tsx    Floating notification
       AgentAvatar.tsx      Status dot + role icon
     Skills/
-      SkillsRulesModal.tsx CRUD editor for skills and rules
+      SkillsModal.tsx      CRUD editor for custom skills + template library
+    Rules/
+      RulesModal.tsx       CRUD editor for rules + template library
   hooks/
     useBuildSession.ts   WebSocket connection + session state
   App.tsx                Root layout, all top-level state (useState)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,8 @@ import MissionControlPanel from './components/MissionControl/MissionControlPanel
 import TeachingToast from './components/shared/TeachingToast';
 import HumanGateModal from './components/shared/HumanGateModal';
 import QuestionModal from './components/shared/QuestionModal';
-import SkillsRulesModal from './components/Skills/SkillsRulesModal';
+import SkillsModal from './components/Skills/SkillsModal';
+import RulesModal from './components/Rules/RulesModal';
 import PortalsModal from './components/Portals/PortalsModal';
 import ExamplePickerModal from './components/shared/ExamplePickerModal';
 import { EXAMPLE_NUGGETS } from './lib/examples';
@@ -79,6 +80,7 @@ export default function App() {
   const [rules, setRules] = useState<Rule[]>(() => readLocalStorageJson<Rule[]>(LS_RULES) ?? []);
   const [portals, setPortals] = useState<Portal[]>(() => readLocalStorageJson<Portal[]>(LS_PORTALS) ?? []);
   const [skillsModalOpen, setSkillsModalOpen] = useState(false);
+  const [rulesModalOpen, setRulesModalOpen] = useState(false);
   const [portalsModalOpen, setPortalsModalOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
 
@@ -386,6 +388,7 @@ export default function App() {
             onOpen={() => fileInputRef.current?.click()}
             onSave={handleSaveNugget}
             onSkills={() => setSkillsModalOpen(true)}
+            onRules={() => setRulesModalOpen(true)}
             onPortals={() => setPortalsModalOpen(true)}
             onExamples={() => setExamplePickerOpen(true)}
             onHelp={() => setHelpOpen(true)}
@@ -458,14 +461,21 @@ export default function App() {
         />
       )}
 
-      {/* Skills & Rules modal */}
+      {/* Skills modal */}
       {skillsModalOpen && (
-        <SkillsRulesModal
+        <SkillsModal
           skills={skills}
-          rules={rules}
           onSkillsChange={setSkills}
-          onRulesChange={setRules}
           onClose={() => setSkillsModalOpen(false)}
+        />
+      )}
+
+      {/* Rules modal */}
+      {rulesModalOpen && (
+        <RulesModal
+          rules={rules}
+          onRulesChange={setRules}
+          onClose={() => setRulesModalOpen(false)}
         />
       )}
 
@@ -521,7 +531,8 @@ export default function App() {
                 <h3 className="font-semibold text-atelier-text mb-1">Sidebar</h3>
                 <ul className="space-y-0.5">
                   <li><span className="text-atelier-text">Open / Save</span> - Load or save .elisa nugget files</li>
-                  <li><span className="text-atelier-text">Skills</span> - Custom agent skills and rules</li>
+                  <li><span className="text-atelier-text">Skills</span> - Custom agent skills and behaviors</li>
+                  <li><span className="text-atelier-text">Rules</span> - Constraints and checks for your agents</li>
                   <li><span className="text-atelier-text">Portals</span> - Connect external tools (MCP, CLI, hardware)</li>
                   <li><span className="text-atelier-text">Examples</span> - Load a pre-built example nugget</li>
                 </ul>

--- a/frontend/src/components/BlockCanvas/WorkspaceSidebar.tsx
+++ b/frontend/src/components/BlockCanvas/WorkspaceSidebar.tsx
@@ -2,6 +2,7 @@ interface WorkspaceSidebarProps {
   onOpen: () => void;
   onSave: () => void;
   onSkills: () => void;
+  onRules: () => void;
   onPortals: () => void;
   onExamples: () => void;
   onHelp: () => void;
@@ -10,21 +11,22 @@ interface WorkspaceSidebarProps {
   workspacePath?: string | null;
 }
 
-const sidebarItems: Array<{ key: string; label: string; prop: keyof Pick<WorkspaceSidebarProps, 'onOpen' | 'onSave' | 'onSkills' | 'onPortals' | 'onExamples' | 'onHelp' | 'onFolder'> }> = [
+const sidebarItems: Array<{ key: string; label: string; prop: keyof Pick<WorkspaceSidebarProps, 'onOpen' | 'onSave' | 'onSkills' | 'onRules' | 'onPortals' | 'onExamples' | 'onHelp' | 'onFolder'> }> = [
   { key: 'folder', label: 'Folder', prop: 'onFolder' },
   { key: 'open', label: 'Open', prop: 'onOpen' },
   { key: 'save', label: 'Save', prop: 'onSave' },
   { key: 'skills', label: 'Skills', prop: 'onSkills' },
+  { key: 'rules', label: 'Rules', prop: 'onRules' },
   { key: 'portals', label: 'Portals', prop: 'onPortals' },
   { key: 'examples', label: 'Examples', prop: 'onExamples' },
   { key: 'help', label: 'Help', prop: 'onHelp' },
 ];
 
 export default function WorkspaceSidebar({
-  onOpen, onSave, onSkills, onPortals, onExamples, onHelp, onFolder, saveDisabled, workspacePath,
+  onOpen, onSave, onSkills, onRules, onPortals, onExamples, onHelp, onFolder, saveDisabled, workspacePath,
 }: WorkspaceSidebarProps) {
   const handlers: Record<string, (() => void) | undefined> = {
-    onOpen, onSave, onSkills, onPortals, onExamples, onHelp, onFolder,
+    onOpen, onSave, onSkills, onRules, onPortals, onExamples, onHelp, onFolder,
   };
 
   return (
@@ -43,13 +45,15 @@ export default function WorkspaceSidebar({
                 ? 'text-atelier-text-muted cursor-not-allowed'
                 : item.key === 'skills'
                   ? 'bg-accent-lavender/10 text-accent-lavender hover:bg-accent-lavender/20'
-                  : item.key === 'portals'
-                    ? 'bg-accent-sky/10 text-accent-sky hover:bg-accent-sky/20'
-                    : item.key === 'examples'
-                      ? 'bg-accent-gold/10 text-accent-gold hover:bg-accent-gold/20'
-                      : item.key === 'folder' && workspacePath
-                        ? 'bg-green-500/10 text-green-400 hover:bg-green-500/20'
-                        : 'text-atelier-text-secondary hover:bg-atelier-elevated hover:text-atelier-text'
+                  : item.key === 'rules'
+                    ? 'bg-accent-coral/10 text-accent-coral hover:bg-accent-coral/20'
+                    : item.key === 'portals'
+                      ? 'bg-accent-sky/10 text-accent-sky hover:bg-accent-sky/20'
+                      : item.key === 'examples'
+                        ? 'bg-accent-gold/10 text-accent-gold hover:bg-accent-gold/20'
+                        : item.key === 'folder' && workspacePath
+                          ? 'bg-green-500/10 text-green-400 hover:bg-green-500/20'
+                          : 'text-atelier-text-secondary hover:bg-atelier-elevated hover:text-atelier-text'
             }`}
           >
             {item.label}

--- a/frontend/src/components/BlockCanvas/skillFlowBlocks.ts
+++ b/frontend/src/components/BlockCanvas/skillFlowBlocks.ts
@@ -36,7 +36,7 @@ const skillFlowBlockDefs = [
     previousStatement: null,
     nextStatement: null,
     colour: 315,
-    tooltip: 'Branch based on a context value. First match wins; remaining blocks run as else path.',
+    tooltip: 'If the context value matches, run the nested blocks. Blocks after this one always run regardless.',
     helpUrl: '',
   },
   {
@@ -67,7 +67,7 @@ const skillFlowBlockDefs = [
     previousStatement: null,
     nextStatement: null,
     colour: 315,
-    tooltip: 'Spawn a Claude agent with a prompt template. Use {{key}} for context values.',
+    tooltip: 'Spawn a Claude agent with a prompt template. Use {{key}} syntax to insert context values (e.g. {{answer}}, {{topic}}).',
     helpUrl: '',
   },
   {

--- a/frontend/src/components/BlockCanvas/toolbox.ts
+++ b/frontend/src/components/BlockCanvas/toolbox.ts
@@ -36,6 +36,13 @@ export const toolbox = {
       colour: '315',
       contents: [
         { kind: 'block', type: 'use_skill' },
+      ],
+    },
+    {
+      kind: 'category',
+      name: 'Rules',
+      colour: '345',
+      contents: [
         { kind: 'block', type: 'use_rule' },
       ],
     },

--- a/frontend/src/components/CLAUDE.md
+++ b/frontend/src/components/CLAUDE.md
@@ -30,7 +30,8 @@ App.tsx
   shared/MinionAvatar.tsx            Animated avatar for narrator/minion characters
   shared/ExamplePickerModal.tsx      Card grid to choose bundled example nuggets
   shared/DirectoryPickerModal.tsx   Text input fallback for non-Electron workspace directory selection
-  Skills/SkillsRulesModal.tsx        CRUD editor for custom skills/rules + template library
+  Skills/SkillsModal.tsx             CRUD editor for custom skills + template library
+  Rules/RulesModal.tsx               CRUD editor for rules + template library
   Portals/PortalsModal.tsx           CRUD editor for portal connections
 ```
 

--- a/frontend/src/components/Rules/RulesModal.test.tsx
+++ b/frontend/src/components/Rules/RulesModal.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RulesModal from './RulesModal';
+import type { Rule } from '../Skills/types';
+
+const defaultProps = {
+  rules: [] as Rule[],
+  onRulesChange: vi.fn(),
+  onClose: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid-1234' });
+});
+
+describe('RulesModal', () => {
+  // --- Empty state ---
+  it('renders empty state correctly', () => {
+    render(<RulesModal {...defaultProps} />);
+    expect(screen.getByText('Rules')).toBeInTheDocument();
+    expect(screen.getByText(/No rules yet/)).toBeInTheDocument();
+  });
+
+  // --- Rule CRUD ---
+  it('creates a new rule', () => {
+    const onRulesChange = vi.fn();
+    render(<RulesModal {...defaultProps} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const nameInput = screen.getByPlaceholderText('e.g. Always Add Comments');
+    fireEvent.change(nameInput, { target: { value: 'Test Rule' } });
+
+    const textareas = screen.getAllByRole('textbox');
+    const promptTextarea = textareas.find(el => el.tagName === 'TEXTAREA')!;
+    fireEvent.change(promptTextarea, { target: { value: 'Test rule prompt' } });
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(onRulesChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: 'Test Rule',
+        prompt: 'Test rule prompt',
+        trigger: 'always',
+      }),
+    ]);
+  });
+
+  it('edits an existing rule name', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'Old Rule', prompt: 'Old prompt', trigger: 'always' },
+    ];
+    const onRulesChange = vi.fn();
+    render(<RulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Edit'));
+
+    expect(screen.getByDisplayValue('Old Rule')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Old prompt')).toBeInTheDocument();
+
+    const nameInput = screen.getByDisplayValue('Old Rule');
+    fireEvent.change(nameInput, { target: { value: 'Updated Rule' } });
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(onRulesChange).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'r1', name: 'Updated Rule', prompt: 'Old prompt' }),
+    ]);
+  });
+
+  it('edits rule prompt', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'My Rule', prompt: 'Old prompt', trigger: 'always' },
+    ];
+    const onRulesChange = vi.fn();
+    render(<RulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Edit'));
+
+    const promptTextarea = screen.getByDisplayValue('Old prompt');
+    fireEvent.change(promptTextarea, { target: { value: 'New prompt' } });
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(onRulesChange).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'r1', name: 'My Rule', prompt: 'New prompt' }),
+    ]);
+  });
+
+  it('edits rule trigger', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'My Rule', prompt: 'prompt text', trigger: 'always' },
+    ];
+    const onRulesChange = vi.fn();
+    render(<RulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Edit'));
+
+    const select = screen.getByDisplayValue('Always on');
+    fireEvent.change(select, { target: { value: 'on_test_fail' } });
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(onRulesChange).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'r1', trigger: 'on_test_fail' }),
+    ]);
+  });
+
+  it('deletes a rule from the list', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'Delete Me', prompt: 'prompt', trigger: 'always' },
+    ];
+    const onRulesChange = vi.fn();
+    render(<RulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onRulesChange).toHaveBeenCalledWith([]);
+  });
+
+  it('deletes a rule from the editor', () => {
+    const rules: Rule[] = [
+      { id: 'r1', name: 'Delete Me', prompt: 'prompt', trigger: 'always' },
+    ];
+    const onRulesChange = vi.fn();
+    render(<RulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('Edit'));
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onRulesChange).toHaveBeenCalledWith([]);
+  });
+
+  // --- Trigger dropdown ---
+  it('changes trigger dropdown correctly', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const select = screen.getByDisplayValue('Always on');
+    fireEvent.change(select, { target: { value: 'on_test_fail' } });
+    expect(screen.getByDisplayValue('On test fail')).toBeInTheDocument();
+  });
+
+  // --- Placeholder text changes per trigger type ---
+  it('shows correct placeholder for always trigger', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+    expect(screen.getByPlaceholderText(/Write a rule that always applies/)).toBeInTheDocument();
+  });
+
+  it('shows correct placeholder for on_task_complete trigger', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const select = screen.getByDisplayValue('Always on');
+    fireEvent.change(select, { target: { value: 'on_task_complete' } });
+
+    expect(screen.getByPlaceholderText(/What should be checked when a task is done/)).toBeInTheDocument();
+  });
+
+  it('shows correct placeholder for on_test_fail trigger', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const select = screen.getByDisplayValue('Always on');
+    fireEvent.change(select, { target: { value: 'on_test_fail' } });
+
+    expect(screen.getByPlaceholderText(/What should happen when tests fail/)).toBeInTheDocument();
+  });
+
+  it('shows correct placeholder for before_deploy trigger', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const select = screen.getByDisplayValue('Always on');
+    fireEvent.change(select, { target: { value: 'before_deploy' } });
+
+    expect(screen.getByPlaceholderText(/What must be true before deploying/)).toBeInTheDocument();
+  });
+
+  // --- Rule template library ---
+  it('renders rule templates', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('From Template'));
+    expect(screen.getByText('Always add comments')).toBeInTheDocument();
+    expect(screen.getByText('Test every feature')).toBeInTheDocument();
+  });
+
+  it('adds a rule from template', () => {
+    const onRulesChange = vi.fn();
+    render(<RulesModal {...defaultProps} onRulesChange={onRulesChange} />);
+    fireEvent.click(screen.getByText('From Template'));
+
+    const addButtons = screen.getAllByText('Add');
+    fireEvent.click(addButtons[0]);
+
+    expect(onRulesChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'test-uuid-1234',
+        name: 'Always add comments',
+        trigger: 'always',
+      }),
+    ]);
+  });
+
+  it('shows (added) badge for duplicate rule template', () => {
+    const rules: Rule[] = [
+      { id: 'custom-1', name: 'Always add comments', prompt: 'custom', trigger: 'always' },
+    ];
+    render(<RulesModal {...defaultProps} rules={rules} />);
+    fireEvent.click(screen.getByText('From Template'));
+
+    const addedBadges = screen.getAllByText('(added)');
+    expect(addedBadges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- Close ---
+  it('calls onClose when X is clicked', () => {
+    const onClose = vi.fn();
+    render(<RulesModal {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByText('X'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // --- Validation ---
+  it('disables Done button until name and prompt are non-empty', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+
+    const doneBtn = screen.getByText('Done');
+    expect(doneBtn).toBeDisabled();
+
+    // Add name only -- still disabled
+    const nameInput = screen.getByPlaceholderText('e.g. Always Add Comments');
+    fireEvent.change(nameInput, { target: { value: 'Has Name' } });
+    expect(doneBtn).toBeDisabled();
+
+    // Add prompt -- now enabled
+    const textareas = screen.getAllByRole('textbox');
+    const promptTextarea = textareas.find(el => el.tagName === 'TEXTAREA')!;
+    fireEvent.change(promptTextarea, { target: { value: 'Has prompt' } });
+    expect(doneBtn).not.toBeDisabled();
+  });
+
+  it('cancels editing and returns to list', () => {
+    render(<RulesModal {...defaultProps} />);
+    fireEvent.click(screen.getByText('+ New Rule'));
+    expect(screen.getByPlaceholderText('e.g. Always Add Comments')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByPlaceholderText('e.g. Always Add Comments')).not.toBeInTheDocument();
+    expect(screen.getByText(/No rules yet/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Rules/RulesModal.tsx
+++ b/frontend/src/components/Rules/RulesModal.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react';
+import type { Rule } from '../Skills/types';
+import { RULE_TEMPLATES } from '../../lib/skillTemplates';
+
+interface Props {
+  rules: Rule[];
+  onRulesChange: (rules: Rule[]) => void;
+  onClose: () => void;
+}
+
+const RULE_PLACEHOLDERS: Record<Rule['trigger'], string> = {
+  always: 'Write a rule that always applies. Example: Every file must have at least one comment explaining what it does.',
+  on_task_complete: 'What should be checked when a task is done? Example: Make sure there are no console.log statements left in the code.',
+  on_test_fail: 'What should happen when tests fail? Example: Look at the error message carefully and fix the exact line that broke.',
+  before_deploy: 'What must be true before deploying? Example: All buttons must have labels and the app must work on mobile.',
+};
+
+const RULE_TRIGGERS: Array<{ label: string; value: Rule['trigger'] }> = [
+  { label: 'Always on', value: 'always' },
+  { label: 'On task complete', value: 'on_task_complete' },
+  { label: 'On test fail', value: 'on_test_fail' },
+  { label: 'Before deploy', value: 'before_deploy' },
+];
+
+const TRIGGER_BADGES: Record<Rule['trigger'], string> = {
+  always: 'bg-accent-sky/20 text-accent-sky',
+  on_task_complete: 'bg-accent-mint/20 text-accent-mint',
+  on_test_fail: 'bg-accent-coral/20 text-accent-coral',
+  before_deploy: 'bg-accent-gold/20 text-accent-gold',
+};
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+type View = 'list' | 'editor' | 'templates';
+
+export default function RulesModal({ rules, onRulesChange, onClose }: Props) {
+  const [view, setView] = useState<View>('list');
+  const [editingRule, setEditingRule] = useState<Rule | null>(null);
+
+  const handleCreate = () => {
+    setEditingRule({ id: generateId(), name: '', prompt: '', trigger: 'always' });
+    setView('editor');
+  };
+
+  const handleEdit = (rule: Rule) => {
+    setEditingRule(rule);
+    setView('editor');
+  };
+
+  const handleSave = (rule: Rule) => {
+    const existing = rules.findIndex(r => r.id === rule.id);
+    if (existing >= 0) {
+      const updated = [...rules];
+      updated[existing] = rule;
+      onRulesChange(updated);
+    } else {
+      onRulesChange([...rules, rule]);
+    }
+    setEditingRule(null);
+    setView('list');
+  };
+
+  const handleDelete = (id: string) => {
+    onRulesChange(rules.filter(r => r.id !== id));
+    if (editingRule?.id === id) {
+      setEditingRule(null);
+      setView('list');
+    }
+  };
+
+  const handleTemplateSelect = (templateIndex: number) => {
+    const tmpl = RULE_TEMPLATES[templateIndex];
+    const alreadyAdded = rules.some(r => r.name === tmpl.name);
+    if (alreadyAdded) return;
+    const newRule: Rule = {
+      id: generateId(),
+      name: tmpl.name,
+      prompt: tmpl.prompt,
+      trigger: tmpl.trigger,
+    };
+    onRulesChange([...rules, newRule]);
+  };
+
+  return (
+    <div className="fixed inset-0 modal-backdrop z-50 flex items-center justify-center" role="dialog" aria-modal="true" aria-labelledby="rules-modal-title">
+      <div className="glass-elevated rounded-2xl shadow-2xl p-6 max-w-lg mx-4 w-full max-h-[80vh] flex flex-col animate-float-in">
+        <div className="flex items-center justify-between mb-4">
+          <h2 id="rules-modal-title" className="text-xl font-display font-bold text-atelier-text">Rules</h2>
+          <button
+            onClick={onClose}
+            className="text-atelier-text-muted hover:text-atelier-text text-lg font-bold transition-colors"
+            aria-label="Close"
+          >
+            X
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {view === 'list' && (
+            <div>
+              {rules.map(rule => (
+                <div key={rule.id} className="border border-border-subtle rounded-xl p-3 mb-2 flex items-start justify-between bg-atelier-surface/40">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-sm text-atelier-text">{rule.name || '(unnamed)'}</span>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${TRIGGER_BADGES[rule.trigger]}`}>
+                        {rule.trigger}
+                      </span>
+                    </div>
+                    <div className="text-xs text-atelier-text-muted mt-1">
+                      {rule.prompt.slice(0, 80)}{rule.prompt.length > 80 ? '...' : ''}
+                    </div>
+                  </div>
+                  <div className="flex gap-1 ml-2">
+                    <button onClick={() => handleEdit(rule)} className="text-xs px-2 py-1 bg-atelier-elevated rounded-lg hover:bg-atelier-hover text-atelier-text-secondary transition-colors">Edit</button>
+                    <button onClick={() => handleDelete(rule.id)} className="text-xs px-2 py-1 bg-accent-coral/10 text-accent-coral rounded-lg hover:bg-accent-coral/20 transition-colors">Delete</button>
+                  </div>
+                </div>
+              ))}
+              {rules.length === 0 && (
+                <p className="text-atelier-text-muted text-sm text-center py-4">No rules yet. Create one to set constraints for your agents.</p>
+              )}
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={handleCreate}
+                  className="flex-1 px-4 py-2 bg-accent-coral text-white rounded-xl hover:bg-accent-coral/80 text-sm font-medium transition-colors"
+                >
+                  + New Rule
+                </button>
+                <button
+                  onClick={() => setView('templates')}
+                  className="flex-1 px-4 py-2 bg-accent-coral/15 text-accent-coral rounded-xl hover:bg-accent-coral/25 text-sm font-medium border border-accent-coral/20 transition-colors"
+                >
+                  From Template
+                </button>
+              </div>
+            </div>
+          )}
+
+          {view === 'editor' && editingRule && (
+            <RuleEditor
+              rule={editingRule}
+              onSave={handleSave}
+              onDelete={() => handleDelete(editingRule.id)}
+              onCancel={() => { setEditingRule(null); setView('list'); }}
+            />
+          )}
+
+          {view === 'templates' && (
+            <div>
+              <button
+                onClick={() => setView('list')}
+                className="text-sm text-atelier-text-muted hover:text-atelier-text-secondary mb-3 transition-colors"
+              >
+                &larr; Back to list
+              </button>
+              <div className="grid grid-cols-1 gap-2">
+                {RULE_TEMPLATES.map((tmpl, i) => {
+                  const added = rules.some(r => r.name === tmpl.name);
+                  return (
+                    <div
+                      key={tmpl.id}
+                      className="border border-border-subtle rounded-xl p-3 bg-atelier-surface/40 flex items-start justify-between"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm text-atelier-text">{tmpl.name}</span>
+                          <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${TRIGGER_BADGES[tmpl.trigger]}`}>
+                            {tmpl.trigger}
+                          </span>
+                        </div>
+                        <p className="text-xs text-atelier-text-muted mt-0.5">{tmpl.description}</p>
+                      </div>
+                      <button
+                        onClick={() => handleTemplateSelect(i)}
+                        disabled={added}
+                        className={`ml-2 text-xs px-3 py-1.5 rounded-lg font-medium transition-colors ${added ? 'bg-accent-mint/10 text-accent-mint' : 'bg-accent-coral text-white hover:bg-accent-coral/80 cursor-pointer'}`}
+                      >
+                        {added ? '(added)' : 'Add'}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RuleEditor({ rule, onSave, onDelete, onCancel }: {
+  rule: Rule;
+  onSave: (rule: Rule) => void;
+  onDelete: () => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(rule.name);
+  const [trigger, setTrigger] = useState<Rule['trigger']>(rule.trigger);
+  const [prompt, setPrompt] = useState(rule.prompt);
+
+  const inputClass = "w-full bg-atelier-surface border border-border-medium rounded-xl px-3 py-2 text-sm text-atelier-text placeholder-atelier-text-muted focus:outline-none focus:ring-2 focus:ring-accent-coral/40";
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-xs font-medium text-atelier-text-secondary mb-1">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="e.g. Always Add Comments"
+          className={inputClass}
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-atelier-text-secondary mb-1">When to apply</label>
+        <select
+          value={trigger}
+          onChange={e => setTrigger(e.target.value as Rule['trigger'])}
+          className={inputClass}
+        >
+          {RULE_TRIGGERS.map(t => (
+            <option key={t.value} value={t.value}>{t.label}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-atelier-text-secondary mb-1">Rule instructions</label>
+        <textarea
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          placeholder={RULE_PLACEHOLDERS[trigger]}
+          rows={6}
+          className={`${inputClass} resize-none`}
+        />
+      </div>
+      <div className="flex gap-2 justify-between">
+        <button onClick={onDelete} className="px-3 py-2 bg-accent-coral/10 text-accent-coral rounded-xl hover:bg-accent-coral/20 text-sm transition-colors">Delete</button>
+        <div className="flex gap-2">
+          <button onClick={onCancel} className="px-3 py-2 bg-atelier-surface text-atelier-text-secondary rounded-xl hover:bg-atelier-elevated text-sm transition-colors">Cancel</button>
+          <button
+            onClick={() => onSave({ ...rule, name, trigger, prompt })}
+            disabled={!name.trim() || !prompt.trim()}
+            className="go-btn px-4 py-2 rounded-xl text-sm font-medium disabled:opacity-50 cursor-pointer"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Skills/SkillFlowEditor.test.tsx
+++ b/frontend/src/components/Skills/SkillFlowEditor.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SkillFlowEditor from './SkillFlowEditor';
+import type { Skill } from './types';
+
+// --- Mocks ---
+
+// Track the most recent onOutput callback for simulating streaming
+let mockStartRun = vi.fn();
+const mockUseSkillSession = {
+  sessionId: null as string | null,
+  running: false,
+  result: null as string | null,
+  error: null as string | null,
+  steps: [] as Array<{ stepId: string; stepType: string; status: string }>,
+  outputs: [] as string[],
+  questionRequest: null as null | { stepId: string; questions: Array<{ question: string }> },
+  startRun: mockStartRun,
+  answerQuestion: vi.fn(),
+};
+
+vi.mock('../../hooks/useSkillSession', () => ({
+  useSkillSession: () => mockUseSkillSession,
+}));
+
+// Mock Blockly: provide enough surface for the component to render
+const mockWorkspaceSvg = {
+  dispose: vi.fn(),
+};
+const mockBlocklySave = vi.fn().mockReturnValue({ blocks: { blocks: [] } });
+const mockBlocklyLoad = vi.fn();
+
+vi.mock('blockly', () => ({
+  default: {},
+  inject: vi.fn(() => mockWorkspaceSvg),
+  serialization: {
+    workspaces: {
+      save: (...args: unknown[]) => mockBlocklySave(...args),
+      load: (...args: unknown[]) => mockBlocklyLoad(...args),
+    },
+  },
+}));
+
+vi.mock('../BlockCanvas/skillFlowBlocks', () => ({
+  registerSkillFlowBlocks: vi.fn(),
+}));
+
+vi.mock('../BlockCanvas/skillFlowToolbox', () => ({
+  skillFlowToolbox: { kind: 'categoryToolbox', contents: [] },
+}));
+
+vi.mock('../BlockCanvas/skillInterpreter', () => ({
+  interpretSkillWorkspace: vi.fn().mockReturnValue({
+    skillId: 'test-skill',
+    skillName: 'Test Skill',
+    steps: [{ id: 's1', type: 'output', template: 'hello' }],
+  }),
+}));
+
+vi.mock('./SkillQuestionModal', () => ({
+  default: ({ stepId }: { stepId: string }) => (
+    <div data-testid="mock-question-modal">Question for {stepId}</div>
+  ),
+}));
+
+const defaultSkill: Skill = {
+  id: 'skill-1',
+  name: 'My Test Skill',
+  prompt: '',
+  category: 'composite',
+};
+
+const defaultProps = {
+  skill: defaultSkill,
+  allSkills: [] as Skill[],
+  onSave: vi.fn(),
+  onClose: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockStartRun = vi.fn();
+  mockUseSkillSession.sessionId = null;
+  mockUseSkillSession.running = false;
+  mockUseSkillSession.result = null;
+  mockUseSkillSession.error = null;
+  mockUseSkillSession.steps = [];
+  mockUseSkillSession.outputs = [];
+  mockUseSkillSession.questionRequest = null;
+  mockUseSkillSession.startRun = mockStartRun;
+});
+
+describe('SkillFlowEditor', () => {
+  it('renders the skill name input with the skill name', () => {
+    render(<SkillFlowEditor {...defaultProps} />);
+    const input = screen.getByPlaceholderText('Skill name') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('My Test Skill');
+  });
+
+  it('renders Save, Run, and Close buttons', () => {
+    render(<SkillFlowEditor {...defaultProps} />);
+    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(screen.getByText('Run')).toBeInTheDocument();
+    expect(screen.getByText('Close')).toBeInTheDocument();
+  });
+
+  it('calls onSave with workspace state when Save is clicked', () => {
+    const onSave = vi.fn();
+    render(<SkillFlowEditor {...defaultProps} onSave={onSave} />);
+    fireEvent.click(screen.getByText('Save'));
+    expect(mockBlocklySave).toHaveBeenCalled();
+    expect(onSave).toHaveBeenCalledWith({ blocks: { blocks: [] } });
+  });
+
+  it('calls startRun when Run is clicked', () => {
+    render(<SkillFlowEditor {...defaultProps} />);
+    fireEvent.click(screen.getByText('Run'));
+    expect(mockStartRun).toHaveBeenCalled();
+  });
+
+  it('disables Run button when running', () => {
+    mockUseSkillSession.running = true;
+    render(<SkillFlowEditor {...defaultProps} />);
+    const runBtn = screen.getByText('Running...');
+    expect(runBtn).toBeDisabled();
+  });
+
+  it('shows progress bar when running', () => {
+    mockUseSkillSession.running = true;
+    mockUseSkillSession.steps = [
+      { stepId: 's1', stepType: 'set_context', status: 'completed' },
+      { stepId: 's2', stepType: 'run_agent', status: 'started' },
+    ];
+    render(<SkillFlowEditor {...defaultProps} />);
+    expect(screen.getByText('Step 1/2')).toBeInTheDocument();
+  });
+
+  it('shows latest output text when running', () => {
+    mockUseSkillSession.running = true;
+    mockUseSkillSession.outputs = ['First output', 'Second output'];
+    mockUseSkillSession.steps = [
+      { stepId: 's1', stepType: 'output', status: 'completed' },
+    ];
+    render(<SkillFlowEditor {...defaultProps} />);
+    expect(screen.getByText('Second output')).toBeInTheDocument();
+  });
+
+  it('shows result on completion', () => {
+    mockUseSkillSession.result = 'Final answer: 42';
+    render(<SkillFlowEditor {...defaultProps} />);
+    expect(screen.getByText('Result: Final answer: 42')).toBeInTheDocument();
+  });
+
+  it('shows error on failure', () => {
+    mockUseSkillSession.error = 'Something went wrong';
+    render(<SkillFlowEditor {...defaultProps} />);
+    expect(screen.getByText('Error: Something went wrong')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Close is clicked', () => {
+    const onClose = vi.fn();
+    render(<SkillFlowEditor {...defaultProps} onClose={onClose} />);
+    fireEvent.click(screen.getByText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows question modal when questionRequest is active', () => {
+    mockUseSkillSession.sessionId = 'session-123';
+    mockUseSkillSession.questionRequest = {
+      stepId: 'step-q1',
+      questions: [{ question: 'Pick color' }],
+    };
+    render(<SkillFlowEditor {...defaultProps} />);
+    expect(screen.getByTestId('mock-question-modal')).toBeInTheDocument();
+    expect(screen.getByText('Question for step-q1')).toBeInTheDocument();
+  });
+
+  it('does not show question modal when sessionId is null', () => {
+    mockUseSkillSession.sessionId = null;
+    mockUseSkillSession.questionRequest = {
+      stepId: 'step-q1',
+      questions: [{ question: 'Pick color' }],
+    };
+    render(<SkillFlowEditor {...defaultProps} />);
+    expect(screen.queryByTestId('mock-question-modal')).not.toBeInTheDocument();
+  });
+
+  it('does not show progress/result bar when idle', () => {
+    render(<SkillFlowEditor {...defaultProps} />);
+    // When not running, no result, no error -- no progress bar
+    expect(screen.queryByText(/Step/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Result:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Error:/)).not.toBeInTheDocument();
+  });
+
+  it('updates skill name via input', () => {
+    render(<SkillFlowEditor {...defaultProps} />);
+    const input = screen.getByPlaceholderText('Skill name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Renamed Skill' } });
+    expect(input.value).toBe('Renamed Skill');
+  });
+});

--- a/frontend/src/components/Skills/SkillQuestionModal.tsx
+++ b/frontend/src/components/Skills/SkillQuestionModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { QuestionPayload } from '../../types';
+import { authFetch } from '../../lib/apiClient';
 
 interface Props {
   stepId: string;
@@ -40,9 +41,8 @@ export default function SkillQuestionModal({ stepId, questions, sessionId, onClo
       payload[questions[i].header] = answers[i];
     }
 
-    await fetch(`/api/skills/${sessionId}/answer`, {
+    await authFetch(`/api/skills/${sessionId}/answer`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ step_id: stepId, answers: payload }),
     });
     onClose();

--- a/frontend/src/components/Skills/SkillsModal.test.tsx
+++ b/frontend/src/components/Skills/SkillsModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import SkillsRulesModal from './SkillsRulesModal';
-import type { Skill, Rule } from './types';
+import SkillsModal from './SkillsModal';
+import type { Skill } from './types';
 
 // Mock SkillFlowEditor
 vi.mock('./SkillFlowEditor', () => ({
@@ -20,36 +20,27 @@ vi.mock('./SkillFlowEditor', () => ({
 
 const defaultProps = {
   skills: [] as Skill[],
-  rules: [] as Rule[],
   onSkillsChange: vi.fn(),
-  onRulesChange: vi.fn(),
   onClose: vi.fn(),
 };
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  // Mock crypto.randomUUID
   vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid-1234' });
 });
 
-describe('SkillsRulesModal', () => {
+describe('SkillsModal', () => {
   // --- Basic rendering ---
   it('renders with tabs', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    expect(screen.getByText('Skills & Rules')).toBeInTheDocument();
+    render(<SkillsModal {...defaultProps} />);
+    expect(screen.getByText('Skills')).toBeInTheDocument();
     expect(screen.getByText('Skills (0)')).toBeInTheDocument();
-    expect(screen.getByText('Rules (0)')).toBeInTheDocument();
+    expect(screen.getByText('Templates')).toBeInTheDocument();
   });
 
   it('shows empty state for skills tab', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     expect(screen.getByText(/No skills yet/)).toBeInTheDocument();
-  });
-
-  it('shows empty state for rules tab', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    fireEvent.click(screen.getByText('Rules (0)'));
-    expect(screen.getByText(/No rules yet/)).toBeInTheDocument();
   });
 
   // --- Skill display ---
@@ -57,38 +48,16 @@ describe('SkillsRulesModal', () => {
     const skills: Skill[] = [
       { id: 's1', name: 'Be Creative', prompt: 'Use bright colors', category: 'style' },
     ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    render(<SkillsModal {...defaultProps} skills={skills} />);
     expect(screen.getByText('Be Creative')).toBeInTheDocument();
     expect(screen.getByText(/style/)).toBeInTheDocument();
-  });
-
-  it('displays existing rules', () => {
-    const rules: Rule[] = [
-      { id: 'r1', name: 'Always Comment', prompt: 'Add comments', trigger: 'always' },
-    ];
-    render(<SkillsRulesModal {...defaultProps} rules={rules} />);
-    fireEvent.click(screen.getByText('Rules (1)'));
-    expect(screen.getByText('Always Comment')).toBeInTheDocument();
-  });
-
-  it('counts skills and rules in tab labels', () => {
-    const skills: Skill[] = [
-      { id: 's1', name: 'S1', prompt: 'p', category: 'agent' },
-      { id: 's2', name: 'S2', prompt: 'p', category: 'feature' },
-    ];
-    const rules: Rule[] = [
-      { id: 'r1', name: 'R1', prompt: 'p', trigger: 'always' },
-    ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} rules={rules} />);
-    expect(screen.getByText('Skills (2)')).toBeInTheDocument();
-    expect(screen.getByText('Rules (1)')).toBeInTheDocument();
   });
 
   it('displays unnamed skill with fallback label', () => {
     const skills: Skill[] = [
       { id: 's1', name: '', prompt: 'some prompt', category: 'agent' },
     ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    render(<SkillsModal {...defaultProps} skills={skills} />);
     expect(screen.getByText('(unnamed)')).toBeInTheDocument();
   });
 
@@ -97,7 +66,7 @@ describe('SkillsRulesModal', () => {
     const skills: Skill[] = [
       { id: 's1', name: 'Long', prompt: longPrompt, category: 'agent' },
     ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    render(<SkillsModal {...defaultProps} skills={skills} />);
     expect(screen.getByText(/A{80}\.\.\./)).toBeInTheDocument();
   });
 
@@ -105,20 +74,20 @@ describe('SkillsRulesModal', () => {
     const skills: Skill[] = [
       { id: 's1', name: 'Composite', prompt: 'desc', category: 'composite' },
     ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    render(<SkillsModal {...defaultProps} skills={skills} />);
     expect(screen.getByText(/visual flow/)).toBeInTheDocument();
   });
 
   // --- Skill editor ---
   it('opens skill editor when clicking New Skill', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
     expect(screen.getByPlaceholderText('e.g. Be Extra Creative')).toBeInTheDocument();
   });
 
   it('saves a new skill', () => {
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
@@ -143,7 +112,7 @@ describe('SkillsRulesModal', () => {
     const skills: Skill[] = [
       { id: 's1', name: 'Old Name', prompt: 'Old prompt', category: 'agent' },
     ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    render(<SkillsModal {...defaultProps} skills={skills} />);
     fireEvent.click(screen.getByText('Edit'));
 
     const nameInput = screen.getByDisplayValue('Old Name');
@@ -158,7 +127,7 @@ describe('SkillsRulesModal', () => {
       { id: 's1', name: 'Old Name', prompt: 'Old prompt', category: 'agent' },
     ];
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('Edit'));
 
     const nameInput = screen.getByDisplayValue('Old Name');
@@ -172,7 +141,7 @@ describe('SkillsRulesModal', () => {
   });
 
   it('cancels editing a skill', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
     expect(screen.getByPlaceholderText('e.g. Be Extra Creative')).toBeInTheDocument();
 
@@ -185,7 +154,7 @@ describe('SkillsRulesModal', () => {
       { id: 's1', name: 'Be Creative', prompt: 'Use bright colors', category: 'style' },
     ];
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('Delete'));
     expect(onSkillsChange).toHaveBeenCalledWith([]);
   });
@@ -195,21 +164,21 @@ describe('SkillsRulesModal', () => {
       { id: 's1', name: 'To Delete', prompt: 'prompt', category: 'agent' },
     ];
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} skills={skills} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('Edit'));
     fireEvent.click(screen.getByText('Delete'));
     expect(onSkillsChange).toHaveBeenCalledWith([]);
   });
 
   it('disables Done when name is empty', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
     const doneBtn = screen.getByText('Done');
     expect(doneBtn).toBeDisabled();
   });
 
   it('disables Done when prompt is empty for non-composite skill', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
@@ -220,7 +189,7 @@ describe('SkillsRulesModal', () => {
   });
 
   it('changes category via select', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const select = screen.getByDisplayValue('Agent behavior');
@@ -230,7 +199,7 @@ describe('SkillsRulesModal', () => {
 
   // --- Composite / Flow Editor ---
   it('shows Open Flow Editor for composite category', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const select = screen.getByDisplayValue('Agent behavior');
@@ -240,7 +209,7 @@ describe('SkillsRulesModal', () => {
   });
 
   it('disables Open Flow Editor when name is empty', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const select = screen.getByDisplayValue('Agent behavior');
@@ -251,7 +220,7 @@ describe('SkillsRulesModal', () => {
 
   it('opens flow editor when clicking Open Flow Editor', () => {
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
@@ -268,7 +237,7 @@ describe('SkillsRulesModal', () => {
 
   it('saves workspace from flow editor', () => {
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
@@ -291,7 +260,7 @@ describe('SkillsRulesModal', () => {
 
   it('closes flow editor without saving', () => {
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('+ New Skill'));
 
     const nameInput = screen.getByPlaceholderText('e.g. Be Extra Creative');
@@ -305,149 +274,34 @@ describe('SkillsRulesModal', () => {
 
     // Should be back to modal, not flow editor
     expect(screen.queryByTestId('mock-flow-editor')).not.toBeInTheDocument();
-    expect(screen.getByText('Skills & Rules')).toBeInTheDocument();
+    expect(screen.getByText('Skills')).toBeInTheDocument();
   });
 
   it('shows flow configured indicator for skill with workspace', () => {
     const skills: Skill[] = [
       { id: 's1', name: 'Configured', prompt: '', category: 'composite', workspace: { blocks: [] } },
     ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
+    render(<SkillsModal {...defaultProps} skills={skills} />);
     fireEvent.click(screen.getByText('Edit'));
     expect(screen.getByText('Flow has been configured.')).toBeInTheDocument();
   });
 
-  // --- Rule editor ---
-  it('opens rule editor when clicking New Rule', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    fireEvent.click(screen.getByText('Rules (0)'));
-    fireEvent.click(screen.getByText('+ New Rule'));
-    expect(screen.getByPlaceholderText('e.g. Always Add Comments')).toBeInTheDocument();
-  });
-
-  it('saves a new rule', () => {
-    const onRulesChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onRulesChange={onRulesChange} />);
-    fireEvent.click(screen.getByText('Rules (0)'));
-    fireEvent.click(screen.getByText('+ New Rule'));
-
-    const nameInput = screen.getByPlaceholderText('e.g. Always Add Comments');
-    fireEvent.change(nameInput, { target: { value: 'Test Rule' } });
-
-    const textareas = screen.getAllByRole('textbox');
-    const promptTextarea = textareas.find(el => el.tagName === 'TEXTAREA')!;
-    fireEvent.change(promptTextarea, { target: { value: 'Test rule prompt' } });
-
-    fireEvent.click(screen.getByText('Done'));
-
-    expect(onRulesChange).toHaveBeenCalledWith([
-      expect.objectContaining({
-        name: 'Test Rule',
-        prompt: 'Test rule prompt',
-        trigger: 'always',
-      }),
-    ]);
-  });
-
-  it('edits an existing rule', () => {
-    const rules: Rule[] = [
-      { id: 'r1', name: 'Old Rule', prompt: 'Old rule prompt', trigger: 'always' },
-    ];
-    render(<SkillsRulesModal {...defaultProps} rules={rules} />);
-    fireEvent.click(screen.getByText('Rules (1)'));
-    fireEvent.click(screen.getByText('Edit'));
-
-    expect(screen.getByDisplayValue('Old Rule')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('Old rule prompt')).toBeInTheDocument();
-  });
-
-  it('deletes a rule from the list', () => {
-    const rules: Rule[] = [
-      { id: 'r1', name: 'Delete Me', prompt: 'prompt', trigger: 'always' },
-    ];
-    const onRulesChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
-    fireEvent.click(screen.getByText('Rules (1)'));
-    fireEvent.click(screen.getByText('Delete'));
-    expect(onRulesChange).toHaveBeenCalledWith([]);
-  });
-
-  it('deletes a rule from the editor', () => {
-    const rules: Rule[] = [
-      { id: 'r1', name: 'Delete Me', prompt: 'prompt', trigger: 'always' },
-    ];
-    const onRulesChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} rules={rules} onRulesChange={onRulesChange} />);
-    fireEvent.click(screen.getByText('Rules (1)'));
-    fireEvent.click(screen.getByText('Edit'));
-    fireEvent.click(screen.getByText('Delete'));
-    expect(onRulesChange).toHaveBeenCalledWith([]);
-  });
-
-  it('cancels editing a rule', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    fireEvent.click(screen.getByText('Rules (0)'));
-    fireEvent.click(screen.getByText('+ New Rule'));
-    expect(screen.getByPlaceholderText('e.g. Always Add Comments')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText('Cancel'));
-    expect(screen.queryByPlaceholderText('e.g. Always Add Comments')).not.toBeInTheDocument();
-  });
-
-  it('changes rule trigger via select', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    fireEvent.click(screen.getByText('Rules (0)'));
-    fireEvent.click(screen.getByText('+ New Rule'));
-
-    const select = screen.getByDisplayValue('Always on');
-    fireEvent.change(select, { target: { value: 'on_test_fail' } });
-    expect(screen.getByDisplayValue('On test fail')).toBeInTheDocument();
-  });
-
-  it('disables Done when rule name or prompt is empty', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    fireEvent.click(screen.getByText('Rules (0)'));
-    fireEvent.click(screen.getByText('+ New Rule'));
-
-    const doneBtn = screen.getByText('Done');
-    expect(doneBtn).toBeDisabled();
-
-    // Add name only
-    const nameInput = screen.getByPlaceholderText('e.g. Always Add Comments');
-    fireEvent.change(nameInput, { target: { value: 'Has Name' } });
-    expect(doneBtn).toBeDisabled();
-  });
-
-  // --- Tab switching ---
-  it('clears skill editor when switching to rules tab', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
-    fireEvent.click(screen.getByText('+ New Skill'));
-    expect(screen.getByPlaceholderText('e.g. Be Extra Creative')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText('Rules (0)'));
-    fireEvent.click(screen.getByText('Skills (0)'));
-    // Editor should be cleared, back to empty state
-    expect(screen.getByText(/No skills yet/)).toBeInTheDocument();
-  });
-
   // --- Templates tab ---
   it('renders Templates tab', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     expect(screen.getByText('Templates')).toBeInTheDocument();
   });
 
-  it('shows skill and rule templates when Templates tab is clicked', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+  it('shows skill templates when Templates tab is clicked', () => {
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('Templates'));
     expect(screen.getByText('Skill Templates')).toBeInTheDocument();
-    expect(screen.getByText('Rule Templates')).toBeInTheDocument();
     expect(screen.getByText('Explain everything')).toBeInTheDocument();
-    expect(screen.getByText('Always add comments')).toBeInTheDocument();
   });
 
   it('adds a skill template with unique ID', () => {
     const onSkillsChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onSkillsChange={onSkillsChange} />);
+    render(<SkillsModal {...defaultProps} onSkillsChange={onSkillsChange} />);
     fireEvent.click(screen.getByText('Templates'));
 
     const addButtons = screen.getAllByText('Add');
@@ -462,44 +316,11 @@ describe('SkillsRulesModal', () => {
     ]);
   });
 
-  it('adds a rule template with unique ID', () => {
-    const onRulesChange = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onRulesChange={onRulesChange} />);
-    fireEvent.click(screen.getByText('Templates'));
-
-    // Skill templates come first, then rule templates. Find the rule "Add" buttons.
-    // The first rule template "Always add comments" has an Add button.
-    const allAddButtons = screen.getAllByText('Add');
-    // Skill templates have 7 Add buttons, rule templates have 8
-    // Click the first rule template Add button (index 7)
-    fireEvent.click(allAddButtons[7]);
-
-    expect(onRulesChange).toHaveBeenCalledWith([
-      expect.objectContaining({
-        id: 'test-uuid-1234',
-        name: 'Always add comments',
-        trigger: 'always',
-      }),
-    ]);
-  });
-
   it('shows (added) badge and disables Add for duplicate skill name', () => {
     const skills: Skill[] = [
       { id: 'custom-1', name: 'Explain everything', prompt: 'custom prompt', category: 'agent' },
     ];
-    render(<SkillsRulesModal {...defaultProps} skills={skills} />);
-    fireEvent.click(screen.getByText('Templates'));
-
-    // The "Explain everything" template should show "(added)" instead of "Add"
-    const addedBadges = screen.getAllByText('(added)');
-    expect(addedBadges.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it('shows (added) badge and disables Add for duplicate rule name', () => {
-    const rules: Rule[] = [
-      { id: 'custom-1', name: 'Always add comments', prompt: 'custom', trigger: 'always' },
-    ];
-    render(<SkillsRulesModal {...defaultProps} rules={rules} />);
+    render(<SkillsModal {...defaultProps} skills={skills} />);
     fireEvent.click(screen.getByText('Templates'));
 
     const addedBadges = screen.getAllByText('(added)');
@@ -507,15 +328,15 @@ describe('SkillsRulesModal', () => {
   });
 
   it('shows helper text on templates tab', () => {
-    render(<SkillsRulesModal {...defaultProps} />);
+    render(<SkillsModal {...defaultProps} />);
     fireEvent.click(screen.getByText('Templates'));
-    expect(screen.getByText(/place a Use Skill or Apply Rule block/)).toBeInTheDocument();
+    expect(screen.getByText(/drag a Use Skill block from the Skills category onto your canvas/)).toBeInTheDocument();
   });
 
   // --- Close ---
   it('calls onClose when X is clicked', () => {
     const onClose = vi.fn();
-    render(<SkillsRulesModal {...defaultProps} onClose={onClose} />);
+    render(<SkillsModal {...defaultProps} onClose={onClose} />);
     fireEvent.click(screen.getByText('X'));
     expect(onClose).toHaveBeenCalled();
   });

--- a/frontend/src/components/Skills/SkillsModal.tsx
+++ b/frontend/src/components/Skills/SkillsModal.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react';
-import type { Skill, Rule } from './types';
+import type { Skill } from './types';
 import SkillFlowEditor from './SkillFlowEditor';
-import { SKILL_TEMPLATES, RULE_TEMPLATES } from '../../lib/skillTemplates';
+import { SKILL_TEMPLATES } from '../../lib/skillTemplates';
 
 interface Props {
   skills: Skill[];
-  rules: Rule[];
   onSkillsChange: (skills: Skill[]) => void;
-  onRulesChange: (rules: Rule[]) => void;
   onClose: () => void;
 }
 
@@ -18,13 +16,6 @@ const SKILL_PLACEHOLDERS: Record<Skill['category'], string> = {
   composite: 'Composite skills are built visually using the Flow Editor.',
 };
 
-const RULE_PLACEHOLDERS: Record<Rule['trigger'], string> = {
-  always: 'Write a rule that always applies. Example: Every file must have at least one comment explaining what it does.',
-  on_task_complete: 'What should be checked when a task is done? Example: Make sure there are no console.log statements left in the code.',
-  on_test_fail: 'What should happen when tests fail? Example: Look at the error message carefully and fix the exact line that broke.',
-  before_deploy: 'What must be true before deploying? Example: All buttons must have labels and the app must work on mobile.',
-};
-
 const SKILL_CATEGORIES: Array<{ label: string; value: Skill['category'] }> = [
   { label: 'Agent behavior', value: 'agent' },
   { label: 'Feature details', value: 'feature' },
@@ -32,29 +23,31 @@ const SKILL_CATEGORIES: Array<{ label: string; value: Skill['category'] }> = [
   { label: 'Composite flow', value: 'composite' },
 ];
 
-const RULE_TRIGGERS: Array<{ label: string; value: Rule['trigger'] }> = [
-  { label: 'Always on', value: 'always' },
-  { label: 'On task complete', value: 'on_task_complete' },
-  { label: 'On test fail', value: 'on_test_fail' },
-  { label: 'Before deploy', value: 'before_deploy' },
-];
+const CATEGORY_HELP: Record<Skill['category'], string> = {
+  agent: 'Controls how the AI agent behaves and communicates.',
+  feature: 'Describes a specific feature or functionality to build.',
+  style: 'Sets the visual style, colors, and aesthetics.',
+  composite: 'Combines multiple skills into a visual flow.',
+};
+
+const CATEGORY_BADGES: Record<Skill['category'], string> = {
+  agent: 'bg-accent-sky/20 text-accent-sky',
+  feature: 'bg-accent-lavender/20 text-accent-lavender',
+  style: 'bg-accent-gold/20 text-accent-gold',
+  composite: 'bg-accent-mint/20 text-accent-mint',
+};
 
 function generateId(): string {
   return crypto.randomUUID();
 }
 
-export default function SkillsRulesModal({ skills, rules, onSkillsChange, onRulesChange, onClose }: Props) {
-  const [activeTab, setActiveTab] = useState<'skills' | 'rules' | 'templates'>('skills');
+export default function SkillsModal({ skills, onSkillsChange, onClose }: Props) {
+  const [activeTab, setActiveTab] = useState<'skills' | 'templates'>('skills');
   const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
-  const [editingRule, setEditingRule] = useState<Rule | null>(null);
   const [flowEditorSkill, setFlowEditorSkill] = useState<Skill | null>(null);
 
   const handleCreateSkill = () => {
     setEditingSkill({ id: generateId(), name: '', prompt: '', category: 'agent' });
-  };
-
-  const handleCreateRule = () => {
-    setEditingRule({ id: generateId(), name: '', prompt: '', trigger: 'always' });
   };
 
   const handleSaveSkill = (skill: Skill) => {
@@ -69,26 +62,9 @@ export default function SkillsRulesModal({ skills, rules, onSkillsChange, onRule
     setEditingSkill(null);
   };
 
-  const handleSaveRule = (rule: Rule) => {
-    const existing = rules.findIndex(r => r.id === rule.id);
-    if (existing >= 0) {
-      const updated = [...rules];
-      updated[existing] = rule;
-      onRulesChange(updated);
-    } else {
-      onRulesChange([...rules, rule]);
-    }
-    setEditingRule(null);
-  };
-
   const handleDeleteSkill = (id: string) => {
     onSkillsChange(skills.filter(s => s.id !== id));
     if (editingSkill?.id === id) setEditingSkill(null);
-  };
-
-  const handleDeleteRule = (id: string) => {
-    onRulesChange(rules.filter(r => r.id !== id));
-    if (editingRule?.id === id) setEditingRule(null);
   };
 
   const handleFlowEditorSave = (workspace: Record<string, unknown>) => {
@@ -114,7 +90,7 @@ export default function SkillsRulesModal({ skills, rules, onSkillsChange, onRule
     <div className="fixed inset-0 modal-backdrop z-50 flex items-center justify-center" role="dialog" aria-modal="true" aria-labelledby="skills-modal-title">
       <div className="glass-elevated rounded-2xl shadow-2xl p-6 max-w-lg mx-4 w-full max-h-[80vh] flex flex-col animate-float-in">
         <div className="flex items-center justify-between mb-4">
-          <h2 id="skills-modal-title" className="text-xl font-display font-bold text-atelier-text">Skills & Rules</h2>
+          <h2 id="skills-modal-title" className="text-xl font-display font-bold text-atelier-text">Skills</h2>
           <button
             onClick={onClose}
             className="text-atelier-text-muted hover:text-atelier-text text-lg font-bold transition-colors"
@@ -127,19 +103,13 @@ export default function SkillsRulesModal({ skills, rules, onSkillsChange, onRule
         {/* Tabs */}
         <div className="flex gap-1 mb-4">
           <button
-            onClick={() => { setActiveTab('skills'); setEditingRule(null); }}
+            onClick={() => { setActiveTab('skills'); }}
             className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${activeTab === 'skills' ? 'bg-accent-lavender/20 text-accent-lavender' : 'bg-atelier-surface/60 text-atelier-text-muted hover:text-atelier-text-secondary'}`}
           >
             Skills ({skills.length})
           </button>
           <button
-            onClick={() => { setActiveTab('rules'); setEditingSkill(null); }}
-            className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${activeTab === 'rules' ? 'bg-accent-coral/20 text-accent-coral' : 'bg-atelier-surface/60 text-atelier-text-muted hover:text-atelier-text-secondary'}`}
-          >
-            Rules ({rules.length})
-          </button>
-          <button
-            onClick={() => { setActiveTab('templates'); setEditingSkill(null); setEditingRule(null); }}
+            onClick={() => { setActiveTab('templates'); setEditingSkill(null); }}
             className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${activeTab === 'templates' ? 'bg-accent-gold/20 text-accent-gold' : 'bg-atelier-surface/60 text-atelier-text-muted hover:text-atelier-text-secondary'}`}
           >
             Templates
@@ -194,47 +164,10 @@ export default function SkillsRulesModal({ skills, rules, onSkillsChange, onRule
             />
           )}
 
-          {activeTab === 'rules' && !editingRule && (
-            <div>
-              {rules.map(rule => (
-                <div key={rule.id} className="border border-border-subtle rounded-xl p-3 mb-2 flex items-start justify-between bg-atelier-surface/40">
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-sm text-atelier-text">{rule.name || '(unnamed)'}</div>
-                    <div className="text-xs text-atelier-text-muted mt-1">{rule.trigger} -- {rule.prompt.slice(0, 80)}{rule.prompt.length > 80 ? '...' : ''}</div>
-                  </div>
-                  <div className="flex gap-1 ml-2">
-                    <button onClick={() => setEditingRule(rule)} className="text-xs px-2 py-1 bg-atelier-elevated rounded-lg hover:bg-atelier-hover text-atelier-text-secondary transition-colors">Edit</button>
-                    <button onClick={() => handleDeleteRule(rule.id)} className="text-xs px-2 py-1 bg-accent-coral/10 text-accent-coral rounded-lg hover:bg-accent-coral/20 transition-colors">Delete</button>
-                  </div>
-                </div>
-              ))}
-              {rules.length === 0 && (
-                <p className="text-atelier-text-muted text-sm text-center py-4">No rules yet. Create one to set constraints for your agents.</p>
-              )}
-              <button
-                onClick={handleCreateRule}
-                className="w-full mt-2 px-4 py-2 bg-accent-coral text-white rounded-xl hover:bg-accent-coral/80 text-sm font-medium transition-colors"
-              >
-                + New Rule
-              </button>
-            </div>
-          )}
-
-          {activeTab === 'rules' && editingRule && (
-            <RuleEditor
-              rule={editingRule}
-              onSave={handleSaveRule}
-              onDelete={() => handleDeleteRule(editingRule.id)}
-              onCancel={() => setEditingRule(null)}
-            />
-          )}
-
           {activeTab === 'templates' && (
             <TemplatesTab
               skills={skills}
-              rules={rules}
               onAddSkill={(skill) => onSkillsChange([...skills, skill])}
-              onAddRule={(rule) => onRulesChange([...rules, rule])}
             />
           )}
         </div>
@@ -279,6 +212,7 @@ function SkillEditor({ skill, onSave, onDelete, onCancel, onOpenFlowEditor }: {
             <option key={c.value} value={c.value}>{c.label}</option>
           ))}
         </select>
+        <p className="text-xs text-atelier-text-muted mt-1">{CATEGORY_HELP[category]}</p>
       </div>
       {isComposite ? (
         <div>
@@ -330,33 +264,16 @@ function SkillEditor({ skill, onSave, onDelete, onCancel, onOpenFlowEditor }: {
   );
 }
 
-const CATEGORY_BADGES: Record<Skill['category'], string> = {
-  agent: 'bg-accent-sky/20 text-accent-sky',
-  feature: 'bg-accent-lavender/20 text-accent-lavender',
-  style: 'bg-accent-gold/20 text-accent-gold',
-  composite: 'bg-accent-mint/20 text-accent-mint',
-};
-
-const TRIGGER_BADGES: Record<Rule['trigger'], string> = {
-  always: 'bg-accent-sky/20 text-accent-sky',
-  on_task_complete: 'bg-accent-mint/20 text-accent-mint',
-  on_test_fail: 'bg-accent-coral/20 text-accent-coral',
-  before_deploy: 'bg-accent-gold/20 text-accent-gold',
-};
-
-function TemplatesTab({ skills, rules, onAddSkill, onAddRule }: {
+function TemplatesTab({ skills, onAddSkill }: {
   skills: Skill[];
-  rules: Rule[];
   onAddSkill: (skill: Skill) => void;
-  onAddRule: (rule: Rule) => void;
 }) {
   const skillNameSet = new Set(skills.map(s => s.name));
-  const ruleNameSet = new Set(rules.map(r => r.name));
 
   return (
     <div className="space-y-4">
       <p className="text-xs text-atelier-text-muted">
-        After adding, place a Use Skill or Apply Rule block in your workspace to activate it.
+        After adding, drag a Use Skill block from the Skills category onto your canvas to activate it.
       </p>
 
       <div>
@@ -383,94 +300,6 @@ function TemplatesTab({ skills, rules, onAddSkill, onAddRule }: {
               </div>
             );
           })}
-        </div>
-      </div>
-
-      <div>
-        <h3 className="text-sm font-semibold text-atelier-text mb-2">Rule Templates</h3>
-        <div className="grid grid-cols-1 gap-2">
-          {RULE_TEMPLATES.map(tmpl => {
-            const added = ruleNameSet.has(tmpl.name);
-            return (
-              <div key={tmpl.id} className="border border-border-subtle rounded-xl p-3 bg-atelier-surface/40 flex items-start justify-between">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-sm text-atelier-text">{tmpl.name}</span>
-                    <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${TRIGGER_BADGES[tmpl.trigger]}`}>{tmpl.trigger}</span>
-                  </div>
-                  <p className="text-xs text-atelier-text-muted mt-0.5">{tmpl.description}</p>
-                </div>
-                <button
-                  onClick={() => onAddRule({ id: crypto.randomUUID(), name: tmpl.name, prompt: tmpl.prompt, trigger: tmpl.trigger })}
-                  disabled={added}
-                  className={`ml-2 text-xs px-3 py-1.5 rounded-lg font-medium transition-colors ${added ? 'bg-accent-mint/10 text-accent-mint' : 'bg-accent-coral text-white hover:bg-accent-coral/80 cursor-pointer'}`}
-                >
-                  {added ? '(added)' : 'Add'}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function RuleEditor({ rule, onSave, onDelete, onCancel }: {
-  rule: Rule;
-  onSave: (rule: Rule) => void;
-  onDelete: () => void;
-  onCancel: () => void;
-}) {
-  const [name, setName] = useState(rule.name);
-  const [trigger, setTrigger] = useState<Rule['trigger']>(rule.trigger);
-  const [prompt, setPrompt] = useState(rule.prompt);
-
-  return (
-    <div className="space-y-3">
-      <div>
-        <label className="block text-xs font-medium text-atelier-text-secondary mb-1">Name</label>
-        <input
-          type="text"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          placeholder="e.g. Always Add Comments"
-          className="w-full bg-atelier-surface border border-border-medium rounded-xl px-3 py-2 text-sm text-atelier-text placeholder-atelier-text-muted focus:outline-none focus:ring-2 focus:ring-accent-coral/40"
-        />
-      </div>
-      <div>
-        <label className="block text-xs font-medium text-atelier-text-secondary mb-1">When to apply</label>
-        <select
-          value={trigger}
-          onChange={e => setTrigger(e.target.value as Rule['trigger'])}
-          className="w-full bg-atelier-surface border border-border-medium rounded-xl px-3 py-2 text-sm text-atelier-text focus:outline-none focus:ring-2 focus:ring-accent-coral/40"
-        >
-          {RULE_TRIGGERS.map(t => (
-            <option key={t.value} value={t.value}>{t.label}</option>
-          ))}
-        </select>
-      </div>
-      <div>
-        <label className="block text-xs font-medium text-atelier-text-secondary mb-1">Rule instructions</label>
-        <textarea
-          value={prompt}
-          onChange={e => setPrompt(e.target.value)}
-          placeholder={RULE_PLACEHOLDERS[trigger]}
-          rows={6}
-          className="w-full bg-atelier-surface border border-border-medium rounded-xl px-3 py-2 text-sm text-atelier-text placeholder-atelier-text-muted focus:outline-none focus:ring-2 focus:ring-accent-coral/40 resize-none"
-        />
-      </div>
-      <div className="flex gap-2 justify-between">
-        <button onClick={onDelete} className="px-3 py-2 bg-accent-coral/10 text-accent-coral rounded-xl hover:bg-accent-coral/20 text-sm transition-colors">Delete</button>
-        <div className="flex gap-2">
-          <button onClick={onCancel} className="px-3 py-2 bg-atelier-surface text-atelier-text-secondary rounded-xl hover:bg-atelier-elevated text-sm transition-colors">Cancel</button>
-          <button
-            onClick={() => onSave({ ...rule, name, trigger, prompt })}
-            disabled={!name.trim() || !prompt.trim()}
-            className="go-btn px-4 py-2 rounded-xl text-sm font-medium disabled:opacity-50 cursor-pointer"
-          >
-            Done
-          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/lib/examples/examples.test.ts
+++ b/frontend/src/lib/examples/examples.test.ts
@@ -75,6 +75,52 @@ describe('bundled example nuggets', () => {
     expect(spec.workflow.review_enabled).toBe(true);
   });
 
+  // skillShowcase-specific tests
+
+  it('skillShowcase example includes a simple skill and a composite skill', () => {
+    const showcase = EXAMPLE_NUGGETS.find((e) => e.id === 'skill-showcase')!;
+    expect(showcase).toBeDefined();
+    const simpleSkill = showcase.skills.find(s => s.category === 'feature');
+    const compositeSkill = showcase.skills.find(s => s.category === 'composite');
+    expect(simpleSkill, 'Missing simple (feature) skill').toBeDefined();
+    expect(compositeSkill, 'Missing composite skill').toBeDefined();
+  });
+
+  it('skillShowcase composite skill has valid workspace JSON', () => {
+    const showcase = EXAMPLE_NUGGETS.find((e) => e.id === 'skill-showcase')!;
+    const compositeSkill = showcase.skills.find(s => s.category === 'composite')!;
+    expect(compositeSkill.workspace).toBeDefined();
+    const ws = compositeSkill.workspace as any;
+    expect(ws.blocks.blocks).toBeDefined();
+    expect(ws.blocks.blocks[0].type).toBe('skill_flow_start');
+  });
+
+  it('skillShowcase example includes an always-trigger rule', () => {
+    const showcase = EXAMPLE_NUGGETS.find((e) => e.id === 'skill-showcase')!;
+    const alwaysRule = showcase.rules.find(r => r.trigger === 'always');
+    expect(alwaysRule, 'Missing always-trigger rule').toBeDefined();
+  });
+
+  it('skillShowcase example uses use_skill and use_rule blocks on canvas', () => {
+    const showcase = EXAMPLE_NUGGETS.find((e) => e.id === 'skill-showcase')!;
+    const ws = showcase.workspace as any;
+    const allBlocks: any[] = [];
+    function collect(block: any) {
+      if (!block) return;
+      allBlocks.push(block);
+      if (block.next?.block) collect(block.next.block);
+      if (block.inputs) {
+        for (const input of Object.values(block.inputs) as any[]) {
+          if ((input as any)?.block) collect((input as any).block);
+        }
+      }
+    }
+    for (const b of ws.blocks.blocks) collect(b);
+    const types = allBlocks.map(b => b.type);
+    expect(types).toContain('use_skill');
+    expect(types).toContain('use_rule');
+  });
+
   // Ensure every skill/rule defined in an example has a corresponding workspace block
   describe('skill/rule block alignment', () => {
     function collectBlockTypes(block: any, results: Array<{ type: string; fields: Record<string, string> }> = []): typeof results {

--- a/frontend/src/lib/examples/index.ts
+++ b/frontend/src/lib/examples/index.ts
@@ -4,6 +4,7 @@ import { simpleWebApp } from './simpleWebApp';
 import { hardwareBlink } from './hardwareBlink';
 import { teamBuild } from './teamBuild';
 import { spaceDodge } from './spaceDodge';
+import { skillShowcase } from './skillShowcase';
 
 export interface ExampleNugget {
   id: string;
@@ -23,4 +24,5 @@ export const EXAMPLE_NUGGETS: ExampleNugget[] = [
   hardwareBlink,
   teamBuild,
   spaceDodge,
+  skillShowcase,
 ];

--- a/frontend/src/lib/examples/skillShowcase.ts
+++ b/frontend/src/lib/examples/skillShowcase.ts
@@ -1,0 +1,180 @@
+import type { ExampleNugget } from './index';
+
+export const skillShowcase: ExampleNugget = {
+  id: 'skill-showcase',
+  name: 'Skill Showcase',
+  description: 'Demonstrates skills, rules, and composite skill flows. Builds a themed landing page with code quality rules.',
+  category: 'web',
+  color: 'bg-purple-100',
+  accentColor: 'text-purple-700',
+  workspace: {
+    blocks: {
+      languageVersion: 0,
+      blocks: [
+        {
+          type: 'nugget_goal',
+          x: 30,
+          y: 30,
+          fields: { GOAL_TEXT: 'A themed landing page that showcases skill and rule features' },
+          next: {
+            block: {
+              type: 'nugget_template',
+              fields: { TEMPLATE_TYPE: 'website' },
+              next: {
+                block: {
+                  type: 'feature',
+                  fields: { FEATURE_TEXT: 'a hero section with a bold headline and call-to-action button' },
+                  next: {
+                    block: {
+                      type: 'feature',
+                      fields: { FEATURE_TEXT: 'a features grid showing three cards with icons' },
+                      next: {
+                        block: {
+                          type: 'look_like',
+                          fields: { STYLE_TEXT: 'modern and clean with a gradient background' },
+                          next: {
+                            block: {
+                              type: 'use_skill',
+                              fields: { SKILL_ID: 'skill-hero-polish' },
+                              next: {
+                                block: {
+                                  type: 'use_skill',
+                                  fields: { SKILL_ID: 'skill-theme-picker' },
+                                  next: {
+                                    block: {
+                                      type: 'use_rule',
+                                      fields: { RULE_ID: 'rule-semantic-html' },
+                                      next: {
+                                        block: {
+                                          type: 'deploy_web',
+                                          fields: {},
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+  skills: [
+    {
+      id: 'skill-hero-polish',
+      name: 'Hero section polish',
+      prompt: 'Make the hero section visually striking: use a large bold font for the headline, add a subtle background animation or gradient shift, and make the call-to-action button pulse gently to draw attention.',
+      category: 'feature',
+    },
+    {
+      id: 'skill-theme-picker',
+      name: 'Theme picker',
+      prompt: 'Apply the chosen color theme to the landing page.',
+      category: 'composite',
+      workspace: {
+        blocks: {
+          blocks: [
+            {
+              type: 'skill_flow_start',
+              id: 'theme-start',
+              next: {
+                block: {
+                  type: 'skill_ask_user',
+                  id: 'theme-ask',
+                  fields: {
+                    QUESTION: 'Which color theme do you want?',
+                    HEADER: 'Theme',
+                    OPTIONS: 'ocean, sunset, forest',
+                    STORE_AS: 'theme',
+                  },
+                  next: {
+                    block: {
+                      type: 'skill_branch_if',
+                      id: 'theme-branch-ocean',
+                      fields: { CONTEXT_KEY: 'theme', MATCH_VALUE: 'ocean' },
+                      inputs: {
+                        THEN_BLOCKS: {
+                          block: {
+                            type: 'skill_run_agent',
+                            id: 'theme-agent-ocean',
+                            fields: {
+                              PROMPT: 'Apply an ocean color theme: use deep blues (#0a2463, #3e92cc), white text, and wave-like gradients.',
+                              STORE_AS: 'theme_result',
+                            },
+                          },
+                        },
+                      },
+                      next: {
+                        block: {
+                          type: 'skill_branch_if',
+                          id: 'theme-branch-sunset',
+                          fields: { CONTEXT_KEY: 'theme', MATCH_VALUE: 'sunset' },
+                          inputs: {
+                            THEN_BLOCKS: {
+                              block: {
+                                type: 'skill_run_agent',
+                                id: 'theme-agent-sunset',
+                                fields: {
+                                  PROMPT: 'Apply a sunset color theme: use warm oranges (#ff6b35, #f7c59f), dark text, and gradient transitions from orange to pink.',
+                                  STORE_AS: 'theme_result',
+                                },
+                              },
+                            },
+                          },
+                          next: {
+                            block: {
+                              type: 'skill_branch_if',
+                              id: 'theme-branch-forest',
+                              fields: { CONTEXT_KEY: 'theme', MATCH_VALUE: 'forest' },
+                              inputs: {
+                                THEN_BLOCKS: {
+                                  block: {
+                                    type: 'skill_run_agent',
+                                    id: 'theme-agent-forest',
+                                    fields: {
+                                      PROMPT: 'Apply a forest color theme: use deep greens (#1b4332, #52b788), cream text, and earthy accent colors.',
+                                      STORE_AS: 'theme_result',
+                                    },
+                                  },
+                                },
+                              },
+                              next: {
+                                block: {
+                                  type: 'skill_output',
+                                  id: 'theme-output',
+                                  fields: { TEMPLATE: '{{theme_result}}' },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+  rules: [
+    {
+      id: 'rule-semantic-html',
+      name: 'Use semantic HTML',
+      prompt: 'Use semantic HTML elements throughout: header, nav, main, section, article, footer. Do not use div for structural layout. Every image must have an alt attribute.',
+      trigger: 'always',
+    },
+  ],
+  portals: [],
+};

--- a/frontend/src/lib/skillTemplates.test.ts
+++ b/frontend/src/lib/skillTemplates.test.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect } from 'vitest';
 import { SKILL_TEMPLATES, RULE_TEMPLATES } from './skillTemplates';
+import { interpretSkillWorkspace } from '../components/BlockCanvas/skillInterpreter';
 
 describe('skillTemplates', () => {
   it('exports non-empty skill templates array', () => {
@@ -68,5 +70,67 @@ describe('skillTemplates', () => {
     for (const tmpl of RULE_TEMPLATES) {
       expect(tmpl.id.startsWith('tmpl-'), `Rule ${tmpl.name} ID missing tmpl- prefix`).toBe(true);
     }
+  });
+
+  describe('composite templates', () => {
+    const compositeTemplates = SKILL_TEMPLATES.filter(t => t.category === 'composite');
+
+    it('has at least two composite templates', () => {
+      expect(compositeTemplates.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('all composite templates have workspace JSON', () => {
+      for (const tmpl of compositeTemplates) {
+        expect(tmpl.workspace, `${tmpl.name} missing workspace`).toBeDefined();
+      }
+    });
+
+    it('all composite template workspaces have valid block structure', () => {
+      for (const tmpl of compositeTemplates) {
+        const ws = tmpl.workspace as any;
+        expect(ws.blocks, `${tmpl.name} missing blocks`).toBeDefined();
+        expect(ws.blocks.blocks, `${tmpl.name} missing blocks.blocks`).toBeDefined();
+        expect(Array.isArray(ws.blocks.blocks), `${tmpl.name} blocks.blocks not an array`).toBe(true);
+        expect(ws.blocks.blocks.length, `${tmpl.name} blocks.blocks is empty`).toBeGreaterThan(0);
+      }
+    });
+
+    it('all composite template workspaces start with skill_flow_start', () => {
+      for (const tmpl of compositeTemplates) {
+        const ws = tmpl.workspace as any;
+        const topBlock = ws.blocks.blocks[0];
+        expect(topBlock.type, `${tmpl.name} first block is not skill_flow_start`).toBe('skill_flow_start');
+      }
+    });
+
+    it('all composite template workspaces produce non-empty skill plans', () => {
+      for (const tmpl of compositeTemplates) {
+        const plan = interpretSkillWorkspace(
+          tmpl.workspace as Record<string, unknown>,
+          tmpl.id,
+          tmpl.name,
+        );
+        expect(plan.steps.length, `${tmpl.name} produced no steps`).toBeGreaterThan(0);
+      }
+    });
+
+    it('presentation builder template asks for topic and format', () => {
+      const pres = compositeTemplates.find(t => t.id === 'tmpl-presentation-builder');
+      expect(pres).toBeDefined();
+      const plan = interpretSkillWorkspace(pres!.workspace as Record<string, unknown>, pres!.id, pres!.name);
+      const askSteps = plan.steps.filter(s => s.type === 'ask_user');
+      expect(askSteps.length).toBe(2);
+      expect(askSteps[0].storeAs).toBe('topic');
+      expect(askSteps[1].storeAs).toBe('format');
+    });
+
+    it('code review checklist template asks for focus area', () => {
+      const review = compositeTemplates.find(t => t.id === 'tmpl-code-review-checklist');
+      expect(review).toBeDefined();
+      const plan = interpretSkillWorkspace(review!.workspace as Record<string, unknown>, review!.id, review!.name);
+      const askSteps = plan.steps.filter(s => s.type === 'ask_user');
+      expect(askSteps.length).toBe(1);
+      expect(askSteps[0].storeAs).toBe('focus');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Separate Rules into a first-class UI element with its own sidebar button, modal, and Blockly toolbox category
- Fix 7 bugs in the Skills system (auth, coercion, answer extraction, invalid blocks, tooltips)
- Add 80+ new tests across frontend and backend (SkillFlowEditor, RulesModal, SkillsModal, skillsRoute, nested composites, streaming, teaching engine)
- Add composite skill templates (Presentation builder, Code review checklist) and Skill Showcase example nugget
- Document all skill flow blocks, Rules category, SkillPlan/SkillStep schemas, and teaching moments

## Test plan

- [x] Backend: 53 test files, 958 tests pass (`cd backend && npx vitest run`)
- [x] Frontend: 37 test files, 530 tests pass (`cd frontend && npx vitest run`)
- [x] Backend lint clean (`cd backend && npm run lint`)
- [x] Zero references to `SkillsRulesModal` remaining (grep verified)
- [x] Zero raw `fetch(` in `frontend/src/components/Skills/` (only `authFetch`)
- [ ] Manual: Skills and Rules are separate sidebar buttons
- [ ] Manual: Rules CRUD works in standalone RulesModal
- [ ] Manual: Blockly toolbox has separate Skills and Rules categories
- [ ] Manual: Composite skill runs correctly in flow editor
- [ ] Manual: Skill Showcase example loads and renders correctly

Generated with [Claude Code](https://claude.com/claude-code)