### PR TITLE
Remove assistant prefill from MetaPlanner

### DIFF
--- a/backend/src/services/metaPlanner.ts
+++ b/backend/src/services/metaPlanner.ts
@@ -45,12 +45,11 @@ export class MetaPlanner {
       system: systemPrompt,
       messages: [
         { role: 'user', content: userMsg },
-        { role: 'assistant', content: '{' },
       ],
       max_tokens: 4096,
     });
 
-    const text = '{' + this.extractText(response);
+    const text = this.extractText(response);
     let plan = this.parseJson(text);
 
     if (!plan) {


### PR DESCRIPTION
## Summary

- Remove assistant message prefill from MetaPlanner API calls
- Opus models do not support prefill; the system prompt already instructs JSON-only output
- Existing `parseJson()` fence-stripping and `retryParse()` handle edge cases for all models
- Add regression test verifying no assistant prefill is used

Fixes: `400 invalid_request_error: This model does not support assistant message prefill` when using `claude-opus-4-6`

## Test plan

- [x] All 20 metaPlanner behavioral tests pass (19 existing + 1 new regression)
- [x] Full backend suite passes (968 tests)
- [ ] CI green
- [ ] Manual test: hit GO in Electron app with Opus model

🤖 Generated with [Claude Code](https://claude.com/claude-code)